### PR TITLE
Feature/77 missing ast info

### DIFF
--- a/etc/test/cpp/string.cpp
+++ b/etc/test/cpp/string.cpp
@@ -177,6 +177,16 @@ TEST( libstdhl_cpp_String, endsWith_false )
     EXPECT_EQ( false, String::endsWith( "foobarbaz", "fffffffffffffffff" ) );
 }
 
+TEST( libstdhl_cpp_String, expansion )
+{
+    //                 0-------------1-----------2-
+    //                 0123456 7 8 9 0 1 2345678901
+    std::string str = "abcdef\n\r\t\t\r\n0123456789";
+    EXPECT_STREQ( String::expansion( str, 0, 3, 8, '.' ).c_str(), "..." );
+    EXPECT_STREQ( String::expansion( str, 5, 6, 8, '.' ).c_str(), "...................." );
+    EXPECT_STREQ( String::expansion( str, 7, 6, 4, '+' ).c_str(), "++++++++++++" );
+}
+
 //
 //  Local variables:
 //  mode: c++

--- a/src/cpp/String.h
+++ b/src/cpp/String.h
@@ -136,6 +136,41 @@ namespace libstdhl
             }
         }
 
+        inline std::string expansion(
+            const std::string& str,
+            const std::size_t start,
+            const std::size_t length,
+            const std::size_t tabSize,
+            const char symbol )
+        {
+            std::string tmp = "";
+            std::size_t bound = start + length;
+
+            if( str.size() == 0 )
+            {
+                return tmp;
+            }
+
+            if( bound >= str.size() )
+            {
+                bound = str.size() - 1;
+            }
+
+            for( auto c = start; c < bound; c++ )
+            {
+                if( str[ c ] == '\t' )
+                {
+                    tmp += std::string( tabSize, symbol );
+                }
+                else
+                {
+                    tmp += symbol;
+                }
+            }
+
+            return tmp;
+        }
+
         /**
            adopted from: https://stackoverflow.com/a/29962178
         */

--- a/src/cpp/String.h
+++ b/src/cpp/String.h
@@ -144,21 +144,11 @@ namespace libstdhl
             const char symbol )
         {
             std::string tmp = "";
-            std::size_t bound = start + length;
-
-            if( str.size() == 0 )
-            {
-                return tmp;
-            }
-
-            if( bound >= str.size() )
-            {
-                bound = str.size() - 1;
-            }
+            const std::size_t bound = start + length;
 
             for( auto c = start; c < bound; c++ )
             {
-                if( str[ c ] == '\t' )
+                if( c < str.size() and str[ c ] == '\t' )
                 {
                     tmp += std::string( tabSize, symbol );
                 }

--- a/src/cpp/log/Formatter.cpp
+++ b/src/cpp/log/Formatter.cpp
@@ -316,38 +316,40 @@ std::string ApplicationFormatter::visit( Data& item )
 
             const auto& location = static_cast< const LocationItem& >( *i );
 
-            std::string line =
+            const auto line =
                 File::readLine( location.filename().text(), location.range().begin().line() );
+            const auto lineStart = location.range().begin().column();
+            auto lineLength = location.range().end().column() - location.range().begin().column();
 
             tmp += "\n" + Ansi::format< 192, 192, 192 >( line ) + "\n";
             tmp +=
                 String::expansion( line, 0, location.range().begin().column() - 1, tabSize(), ' ' );
-            tmp += Ansi::format< Ansi::Color::GREEN >(
-                Ansi::format< Ansi::Style::BOLD >( "^" ) + Ansi::CSI( Ansi::SGR::RESET ) );
+            tmp += Ansi::format< Ansi::Color::GREEN >( Ansi::format< Ansi::Style::BOLD >( "^" ) );
+            tmp += Ansi::CSI( Ansi::SGR::RESET );
 
-            std::string underline;
             if( ( location.range().begin().line() == location.range().end().line() ) and
                 ( location.range().end().column() > location.range().begin().column() ) )
             {
-                const auto lineStart = location.range().begin().column() - 1;
-                const auto lineLength =
-                    location.range().end().column() - location.range().begin().column();
-                underline = String::expansion( line, lineStart, lineLength, tabSize(), '-' );
-                underline.pop_back();
+                if( lineLength > 2 )
+                {
+                    lineLength -= 2;
+                    tmp += Ansi::format< Ansi::Color::GREEN >(
+                        String::expansion( line, lineStart, lineLength, tabSize(), '-' ) );
+                    tmp += Ansi::format< Ansi::Color::GREEN >(
+                        Ansi::format< Ansi::Style::BOLD >( "^" ) );
+                }
+                else if( lineLength == 2 )
+                {
+                    tmp += Ansi::format< Ansi::Color::GREEN >(
+                        Ansi::format< Ansi::Style::BOLD >( "^" ) );
+                }
             }
             else
             {
-                const auto lineStart = 0;
-                auto lineLength = line.size();
-                if( lineLength > 0 )
-                {
-                    lineLength -= 1;
-                }
-                underline =
-                    String::expansion( line, lineStart, lineLength, tabSize(), '-' ) + "...";
+                tmp += Ansi::format< Ansi::Color::GREEN >(
+                    String::expansion( line, lineStart, lineLength, tabSize(), '-' ) + "..." );
             }
-
-            tmp += Ansi::format< Ansi::Color::GREEN >( underline );
+            tmp += Ansi::CSI( Ansi::SGR::RESET );
         }
     }
 

--- a/src/cpp/log/Formatter.h
+++ b/src/cpp/log/Formatter.h
@@ -116,6 +116,10 @@ namespace libstdhl
           public:
             ApplicationFormatter( const std::string& name );
 
+            void setTabSize( const u8 tabSize );
+
+            u8 tabSize( void ) const;
+
             void setRawOutput( const u1 enable );
 
             void setDetailedLocation( const u1 enable );
@@ -126,6 +130,7 @@ namespace libstdhl
 
           private:
             std::string m_name;
+            u8 m_tabSize;
             u1 m_rawOutput;
             u1 m_detailedLocation;
         };


### PR DESCRIPTION
- Provides new C++ `String` API function to construct expansion strings of a defined length based on the input characters from an existing `std::string` text. Important is that tabular characters are encoded to spaces into a defined space length.

- Replaced and improved the C++ `ApplicationFormatter` to use the new `String::expansion()` functionality.

- related casm-lang/casm#77
