### PR TITLE
Improving LSP Implementation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/ECMGenerateHeaders.cmake
+++ b/.cmake/ECMGenerateHeaders.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/Findlibgtest.cmake
+++ b/.cmake/Findlibgtest.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/Findlibhayai.cmake
+++ b/.cmake/Findlibhayai.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/Findlibstdhl.cmake
+++ b/.cmake/Findlibstdhl.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/LibCompile.cmake
+++ b/.cmake/LibCompile.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/LibPackage.cmake
+++ b/.cmake/LibPackage.cmake
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.cmake/config.mk
+++ b/.cmake/config.mk
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -4,6 +4,7 @@ All rights reserved.
 
 Developed by: Philipp Paulweber
               Emmanuel Pescosta
+              Christian Lascsak
               <https://github.com/casm-lang/libstdhl>
 
 This file is part of libstdhl.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/README.org
+++ b/README.org
@@ -4,6 +4,7 @@
 # 
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 # 
 #   This file is part of libstdhl.
@@ -80,6 +81,7 @@ All rights reserved.
 
 Developed by: Philipp Paulweber
               Emmanuel Pescosta
+              Christian Lascsak
               <https://github.com/casm-lang/libstdhl>
 
 This file is part of libstdhl.

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/etc/benchmark/CMakeLists.txt
+++ b/etc/benchmark/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/etc/benchmark/main.cpp
+++ b/etc/benchmark/main.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/CMakeLists.txt
+++ b/etc/test/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/etc/test/cpp/args.cpp
+++ b/etc/test/cpp/args.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/data/type/TODO.cpp
+++ b/etc/test/cpp/data/type/TODO.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/data/type/data.cpp
+++ b/etc/test/cpp/data/type/data.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/data/type/integer.cpp
+++ b/etc/test/cpp/data/type/integer.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/data/type/rational.cpp
+++ b/etc/test/cpp/data/type/rational.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/enum.cpp
+++ b/etc/test/cpp/enum.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/environment.cpp
+++ b/etc/test/cpp/environment.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/exception.cpp
+++ b/etc/test/cpp/exception.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/hash.cpp
+++ b/etc/test/cpp/hash.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/json.cpp
+++ b/etc/test/cpp/json.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/list.cpp
+++ b/etc/test/cpp/list.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/log.cpp
+++ b/etc/test/cpp/log.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/logger.cpp
+++ b/etc/test/cpp/logger.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/math.cpp
+++ b/etc/test/cpp/math.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/memory.cpp
+++ b/etc/test/cpp/memory.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2014-2018 CASM Organization <https://casm-lang.org>
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
 //  All rights reserved.
 //
 //  Developed by: Philipp Paulweber

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -78,6 +78,28 @@ TEST( libstdhl_cpp_network_lsp_content, ColorProvider )
     ColorProvider test( boolean );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, Workspace_WorkspaceFolders )
+{
+    auto folders = Workspace::WorkspaceFolders( Data::object() );
+    EXPECT_FALSE( folders.hasSupported() );
+    EXPECT_FALSE( folders.hasChangeNotifications() );
+    folders.setSupported( true );
+    folders.setChangeNotifications( true );
+    folders.changeNotifications();
+    folders.setChangeNotifications( text );
+    EXPECT_TRUE( folders.hasSupported() );
+    EXPECT_TRUE( folders.hasChangeNotifications() );
+    folders.supported();
+    folders.changeNotifications();
+}
+TEST( libstdhl_cpp_network_lsp_content, Workspace )
+{
+    auto workspace = Workspace( Data::object() );
+    EXPECT_FALSE( workspace.hasWorkspaceFolders() );
+    workspace.setWorkspaceFolders( Workspace::WorkspaceFolders( Data::object() ) );
+    EXPECT_TRUE( workspace.hasWorkspaceFolders() );
+    workspace.workspaceFolders();
+}
 TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
 {
     auto options = CreateFileOptions( true, false );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -97,6 +97,20 @@ TEST( libstdhl_cpp_network_lsp_content, RenameFile )
     EXPECT_STREQ( file.oldUri().toString().c_str(), uri.toString().c_str() );
     EXPECT_STREQ( file.kind().c_str(), Identifier::rename );
 }
+TEST( libstdhl_cpp_network_lsp_content, DeleteFileOptions )
+{
+    auto options = DeleteFileOptions( Data::object() );
+    EXPECT_FALSE( options.hasIgnoreIfExists() );
+    EXPECT_FALSE( options.hasRecursive() );
+    options.setRecursive( true );
+    options.setIgnoreIfExists( true );
+    EXPECT_TRUE( options.hasIgnoreIfExists() );
+    EXPECT_TRUE( options.hasRecursive() );
+    EXPECT_TRUE( options.ignoreIfExists() );
+    EXPECT_TRUE( options.recursive() );
+    DeleteFileOptions test = DeleteFileOptions( options );
+    EXPECT_EQ( options, test );
+}
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
     auto params = CancelParams( 1 );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -670,6 +670,19 @@ TEST( libstdhl_cpp_network_lsp_content, SignatureHelp )
     EXPECT_EQ( help.activeParameter(), 1 );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, SignatureHelpResult )
+{
+    auto signatures = SignatureInformations();
+    signatures.emplace_back( SignatureInformation( label ) );
+    auto help = SignatureHelp( signatures );
+    auto result = SignatureHelpResult( help );
+    auto empty = SignatureHelpResult();
+    auto test = SignatureHelpResult( result );
+    EXPECT_STREQ( result.dump().c_str(), help.dump().c_str() );
+    EXPECT_STREQ( empty.dump().c_str(), Data().dump().c_str() );
+    EXPECT_STREQ( test.dump().c_str(), help.dump().c_str() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, TypeDefinitionResult )
 {
     auto result = TypeDefinitionResult( Data() );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -1137,7 +1137,7 @@ TEST( libstdhl_cpp_network_lsp_content, DocumentOnTypeFormattingParams )
     params.textDocument();
     params.options();
     params.position();
-    EXPECT_STREQ( params.ch().c_str(), "c" );
+    EXPECT_STREQ( params.character().c_str(), "c" );
 }
 
 TEST( libstdhl_cpp_network_lsp_content, DocumentOnTypeFormattingRegistrationOptions )

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -111,6 +111,17 @@ TEST( libstdhl_cpp_network_lsp_content, DeleteFileOptions )
     DeleteFileOptions test = DeleteFileOptions( options );
     EXPECT_EQ( options, test );
 }
+TEST( libstdhl_cpp_network_lsp_content, DeleteFile )
+{
+    auto file = DeleteFile( uri );
+    DeleteFile test( file );
+    EXPECT_EQ( file, test );
+    EXPECT_FALSE( file.hasOptions() );
+    file.setOptions( DeleteFileOptions( Data::object() ) );
+    EXPECT_TRUE( file.hasOptions() );
+    EXPECT_STREQ( file.uri().toString().c_str(), uri.toString().c_str() );
+    EXPECT_STREQ( file.kind().c_str(), Identifier::DELETE );
+}
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
     auto params = CancelParams( 1 );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -683,6 +683,20 @@ TEST( libstdhl_cpp_network_lsp_content, SignatureHelpResult )
     EXPECT_STREQ( test.dump().c_str(), help.dump().c_str() );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, LocationLink )
+{
+    auto link = LocationLink( uri, range );
+    LocationLink l( link );
+    EXPECT_STREQ( link.targetUri().toString().c_str(), uri.toString().c_str() );
+    EXPECT_STREQ( link.targetRange().dump().c_str(), range.dump().c_str() );
+    EXPECT_FALSE( link.hasOriginSelectionRange() );
+    EXPECT_FALSE( link.hasTargetSelectionRange() );
+    link.setOriginSelectionRange( range );
+    link.setTargetSelectionRange( range );
+    EXPECT_TRUE( link.hasOriginSelectionRange() );
+    EXPECT_TRUE( link.hasTargetSelectionRange() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, TypeDefinitionResult )
 {
     auto result = TypeDefinitionResult( Data() );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -61,6 +61,19 @@ const auto method = std::string( "method" );
 const auto name = std::string( "name" );
 const auto id = std::string( "id" );
 
+TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
+{
+    auto options = CreateFileOptions( true, false );
+    auto op = CreateFileOptions( Data::object() );
+    EXPECT_FALSE( op.hasOverwrite() );
+    EXPECT_FALSE( op.hasIgnoreIfExists() );
+    op.setOverwrite( true );
+    op.setIgnoreIfExists( true );
+    EXPECT_TRUE( op.hasOverwrite() );
+    EXPECT_TRUE( op.hasIgnoreIfExists() );
+    EXPECT_TRUE( options.overwrite() );
+    EXPECT_FALSE( options.ignoreIfExists() );
+}
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
     auto params = CancelParams( 1 );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -176,7 +176,7 @@ TEST( libstdhl_cpp_network_lsp_content, DeleteFile )
     file.setOptions( DeleteFileOptions( Data::object() ) );
     EXPECT_TRUE( file.hasOptions() );
     EXPECT_STREQ( file.uri().toString().c_str(), uri.toString().c_str() );
-    EXPECT_STREQ( file.kind().c_str(), Identifier::DELETE );
+    EXPECT_STREQ( file.kind().c_str(), Identifier::deletion );
 }
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
@@ -345,8 +345,8 @@ TEST( libstdhl_cpp_network_lsp_content, WorkspaceFoldersResult )
     vector.emplace_back( folder );
     auto result = WorkspaceFoldersResult( vector );
     result.push_back( folder );
-    EXPECT_STREQ( result.toVec()[ 0 ].uri().c_str(), "test://uri" );
-    EXPECT_STREQ( result.toVec()[ 0 ].name().c_str(), name.c_str() );
+    EXPECT_STREQ( result.workspaceFolders()[ 0 ].uri().c_str(), "test://uri" );
+    EXPECT_STREQ( result.workspaceFolders()[ 0 ].name().c_str(), name.c_str() );
     EXPECT_STREQ( result[ 1 ][ "uri" ].get< std::string >().c_str(), "test://uri" );
     EXPECT_STREQ( result[ 1 ][ name ].get< std::string >().c_str(), name.c_str() );
 }

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -614,6 +614,22 @@ TEST( libstdhl_cpp_network_lsp_content, CompletionList )
     EXPECT_STREQ( list.items()[ 0 ].label().c_str(), label.c_str() );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, CompletionResult )
+{
+    auto items = CompletionItems();
+    items.emplace_back( CompletionItem( label ) );
+    auto list = CompletionList( true, items );
+    auto falselist = CompletionList( false, items );
+    CompletionResult result( list );
+    CompletionResult r( items );
+    auto empty = CompletionResult();
+    CompletionResult test( r );
+    EXPECT_STREQ( result.dump().c_str(), list.dump().c_str() );
+    EXPECT_STREQ( r.dump().c_str(), falselist.dump().c_str() );
+    EXPECT_STREQ( test.dump().c_str(), r.dump().c_str() );
+    EXPECT_STREQ( empty.dump().c_str(), Data().dump().c_str() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, ParameterInformation )
 {
     auto information = ParameterInformation( label );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -703,8 +703,12 @@ TEST( libstdhl_cpp_network_lsp_content, TypeDefinitionResult )
     auto r = TypeDefinitionResult( Location( uri, range ) );
     EXPECT_STREQ( r[ Identifier::uri ].get< std::string >().c_str(), uri.toString().c_str() );
     auto locations = Locations{ location, location, location };
+    auto locationLinks = LocationLinks();
+    locationLinks.push_back( LocationLink( uri, range ) );
     auto typeDefinitionResult = TypeDefinitionResult( locations );
     auto res = TypeDefinitionResult( typeDefinitionResult );
+    auto otherRes = TypeDefinitionResult( locationLinks );
+    TypeDefinitionResult test( otherRes );
     EXPECT_STREQ(
         typeDefinitionResult[ 0 ][ Identifier::uri ].get< std::string >().c_str(),
         uri.toString().c_str() );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -100,6 +100,16 @@ TEST( libstdhl_cpp_network_lsp_content, Workspace )
     EXPECT_TRUE( workspace.hasWorkspaceFolders() );
     workspace.workspaceFolders();
 }
+
+TEST( libstdhl_cpp_network_lsp_content, RenameOptions )
+{
+    auto options = RenameOptions( Data::object() );
+    EXPECT_FALSE( options.hasPrepareProvider() );
+    options.setPrepareProvider( true );
+    EXPECT_TRUE( options.hasPrepareProvider() );
+    EXPECT_TRUE( options.prepareProvider() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
 {
     auto options = CreateFileOptions( true, false );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -123,6 +123,13 @@ TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
     EXPECT_TRUE( options.overwrite() );
     EXPECT_FALSE( options.ignoreIfExists() );
 }
+
+TEST( libstdhl_cpp_network_lsp_content, DiagnosticRelatedInformation )
+{
+    auto information = DiagnosticRelatedInformation( location, message );
+    EXPECT_EQ( information.location(), location );
+    EXPECT_STREQ( information.message().c_str(), message.c_str() );
+}
 TEST( libstdhl_cpp_network_lsp_content, CreateFile )
 {
     auto createFile = CreateFile( uri );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -1226,6 +1226,7 @@ TEST( libstdhl_cpp_network_lsp_content, FoldingRange )
     EXPECT_EQ( foldingRange.endCharacter(), 4 );
     auto f = FoldingRange( foldingRange );
 }
+
 TEST( libstdhl_cpp_network_lsp_content, FoldingRangeResult )
 {
     auto empty = FoldingRangeResult();

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -85,6 +85,18 @@ TEST( libstdhl_cpp_network_lsp_content, CreateFile )
     EXPECT_STREQ( createFile.uri().toString().c_str(), uri.toString().c_str() );
     EXPECT_STREQ( createFile.kind().c_str(), Identifier::create );
 }
+TEST( libstdhl_cpp_network_lsp_content, RenameFile )
+{
+    auto file = RenameFile( uri, uri );
+    RenameFile test( file );
+    EXPECT_EQ( file, test );
+    EXPECT_FALSE( file.hasOptions() );
+    file.setOptions( CreateFileOptions( true, true ) );
+    EXPECT_TRUE( file.hasOptions() );
+    EXPECT_STREQ( file.newUri().toString().c_str(), uri.toString().c_str() );
+    EXPECT_STREQ( file.oldUri().toString().c_str(), uri.toString().c_str() );
+    EXPECT_STREQ( file.kind().c_str(), Identifier::rename );
+}
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
     auto params = CancelParams( 1 );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -1236,6 +1236,7 @@ TEST( libstdhl_cpp_network_lsp_content, FoldingRangeResult )
     auto test = FoldingRangeResult( empty );
     test = FoldingRangeResult( result );
 }
+
 //
 //  Local variables:
 //  mode: c++

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -83,6 +83,20 @@ TEST( libstdhl_cpp_network_lsp_content, MessageActionItem )
     EXPECT_STREQ( item.title().c_str(), title.c_str() );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, ShowMessageRequestResult )
+{
+    auto item = MessageActionItem( title );
+    auto result = ShowMessageRequestResult( title );
+    auto empty = ShowMessageRequestResult();
+    Data data = Data::object();
+    data[ Identifier::title ] = title;
+    auto r = ShowMessageRequestResult( data );
+    ShowMessageRequestResult test( item );
+    EXPECT_STREQ( item.title().c_str(), result[ Identifier::title ].get< std::string >().c_str() );
+    EXPECT_STREQ( empty.dump().c_str(), Data().dump().c_str() );
+    EXPECT_STREQ( r.dump().c_str(), item.dump().c_str() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, ShowMessageRequestParams )
 {
     auto params = ShowMessageRequestParams( MessageType::Error, message );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -68,6 +68,16 @@ TEST( libstdhl_cpp_network_lsp_content, TypeDefinitionProvider )
     Data boolean = true;
     TypeDefinitionProvider test( boolean );
 }
+
+TEST( libstdhl_cpp_network_lsp_content, ColorProvider )
+{
+    ColorProvider provider = ColorProvider(
+        TextDocumentRegistrationOptions( DocumentSelector( std::vector< DocumentFilter >() ) ) );
+    Data boolean = true;
+    ColorProvider options( Data::object() );
+    ColorProvider test( boolean );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
 {
     auto options = CreateFileOptions( true, false );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -61,6 +61,13 @@ const auto method = std::string( "method" );
 const auto name = std::string( "name" );
 const auto id = std::string( "id" );
 
+TEST( libstdhl_cpp_network_lsp_content, TypeDefinitionProvider )
+{
+    TypeDefinitionProvider provider = TypeDefinitionProvider(
+        TextDocumentRegistrationOptions( DocumentSelector( std::vector< DocumentFilter >() ) ) );
+    Data boolean = true;
+    TypeDefinitionProvider test( boolean );
+}
 TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
 {
     auto options = CreateFileOptions( true, false );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -279,6 +279,12 @@ TEST( libstdhl_cpp_network_lsp_content, ConfigurationItem )
     EXPECT_TRUE( item.hasSection() );
 }
 
+TEST( libstdhl_cpp_network_lsp_content, ConfigurationResult )
+{
+    auto empty = ConfigurationResult();
+    auto result = ConfigurationResult( Data::array() );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, ConfigurationParams )
 {
     auto item = ConfigurationItem( Data::object() );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -892,7 +892,9 @@ TEST( libstdhl_cpp_network_lsp_content, DocumentLink )
 TEST( libstdhl_cpp_network_lsp_content, DocumentLinkResult )
 {
     auto empty = DocumentLinkResult();
-    auto result = DocumentLinkResult( DocumentLink( range ) );
+    auto links = DocumentLinks();
+    links.emplace_back( DocumentLink( range ) );
+    auto result = DocumentLinkResult( links );
     auto r = DocumentLinkResult( result );
 }
 

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -61,6 +61,15 @@ const auto method = std::string( "method" );
 const auto name = std::string( "name" );
 const auto id = std::string( "id" );
 
+TEST( libstdhl_cpp_network_lsp_content, CancelParams )
+{
+    auto params = CancelParams( 1 );
+    auto p = CancelParams( params );
+    auto s = CancelParams( std::string( "2" ) );
+    EXPECT_STREQ( params.id().c_str(), "1" );
+    EXPECT_STREQ( s.id().c_str(), "2" );
+}
+
 TEST( libstdhl_cpp_network_lsp_content, ShowMessageParams )
 {
     auto params = ShowMessageParams( MessageType::Error, message );

--- a/etc/test/cpp/net/lsp/content.cpp
+++ b/etc/test/cpp/net/lsp/content.cpp
@@ -74,6 +74,17 @@ TEST( libstdhl_cpp_network_lsp_content, CreateFileOptions )
     EXPECT_TRUE( options.overwrite() );
     EXPECT_FALSE( options.ignoreIfExists() );
 }
+TEST( libstdhl_cpp_network_lsp_content, CreateFile )
+{
+    auto createFile = CreateFile( uri );
+    CreateFile test( createFile );
+    EXPECT_EQ( createFile, test );
+    EXPECT_FALSE( createFile.hasOptions() );
+    createFile.setOptions( CreateFileOptions( true, true ) );
+    EXPECT_TRUE( createFile.hasOptions() );
+    EXPECT_STREQ( createFile.uri().toString().c_str(), uri.toString().c_str() );
+    EXPECT_STREQ( createFile.kind().c_str(), Identifier::create );
+}
 TEST( libstdhl_cpp_network_lsp_content, CancelParams )
 {
     auto params = CancelParams( 1 );

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -492,7 +492,10 @@ TEST( libstdhl_cpp_network_lsp, client_unregisterCapability )
     Unregistration reg2( "2", "test/method" );
     auto unregistrations = std::vector< Unregistration >( { reg, reg2 } );
     server.client_unregisterCapability(
-        UnregistrationParams( unregistrations ), [&]( void ) { processed = true; } );
+        UnregistrationParams( unregistrations ), [&]( const ResponseMessage& response ) {
+            processed = true;
+            EXPECT_EQ( response.result(), Data() );
+        } );
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
         id = static_cast< const RequestMessage& >( message ).id();

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -378,10 +378,10 @@ TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
     server.window_showMessageRequest(
         params, [&]( const ShowMessageRequestResult& result ) { processed = true; } );
 
-    std::string id = "";
+    std::string id = "0";
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
-        id = static_cast< const ResponseMessage& >( message ).id();
+        // id = static_cast< const RequestMessage& >( message ).id();
     } );
 
     ResponseMessage response( id );

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -72,6 +72,9 @@ class TestInterface final : public ServerInterface
     void exit( void ) noexcept override
     {
     }
+    void client_cancel( const CancelParams& params ) noexcept override
+    {
+    }
 
     ExecuteCommandResult workspace_executeCommand( const ExecuteCommandParams& params ) override
     {

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -454,18 +454,11 @@ TEST( libstdhl_cpp_network_lsp, ID_increment )
         messageRequestProcessed = true;
         ShowMessageRequestResult result( response.result() );
     } );
-    server.flush( [&]( const Message& message ) {
-        const auto packet = libstdhl::Network::LSP::Packet( message );
-        id = static_cast< const RequestMessage& >( message ).id();
-    } );
-
-    ResponseMessage response( id );
+    ResponseMessage response( 0 );
     response.setResult( MessageActionItem( std::string{ "title" } ) );
     EXPECT_FALSE( messageRequestProcessed );
     response.process( server );
     EXPECT_TRUE( messageRequestProcessed );
-    EXPECT_STREQ( id.c_str(), "0" );
-
     // make second request
     u1 registerRequestProcessed = false;
     server.client_registerCapability(

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -423,7 +423,10 @@ TEST( libstdhl_cpp_network_lsp, client_registerCapability )
     Registration reg2( "2", "test/method" );
     auto registrations = std::vector< Registration >( { reg, reg2 } );
     server.client_registerCapability(
-        RegistrationParams( registrations ), [&]( void ) { processed = true; } );
+        RegistrationParams( registrations ), [&]( const ResponseMessage& response ) {
+            processed = true;
+            EXPECT_EQ( Data(), response.result() );
+        } );
     Data registrationsData( Data::object() );
     registrationsData[ "registrations" ].push_back( reg );
 
@@ -433,6 +436,7 @@ TEST( libstdhl_cpp_network_lsp, client_registerCapability )
         id = static_cast< const RequestMessage& >( message ).id();
     } );
     ResponseMessage response( id );
+    response.setResult( Data() );
     EXPECT_FALSE( processed );
     response.process( server );
     EXPECT_TRUE( processed );
@@ -465,7 +469,8 @@ TEST( libstdhl_cpp_network_lsp, ID_increment )
     // make second request
     u1 registerRequestProcessed = false;
     server.client_registerCapability(
-        RegistrationParams( Registrations() ), [&]( void ) { registerRequestProcessed = true; } );
+        RegistrationParams( Registrations() ),
+        [&]( const ResponseMessage& ) { registerRequestProcessed = true; } );
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
         id = static_cast< const RequestMessage& >( message ).id();

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -500,6 +500,27 @@ TEST( libstdhl_cpp_network_lsp, client_unregisterCapability )
     EXPECT_STREQ( id.c_str(), "0" );
 }
 
+TEST( libstdhl_cpp_network_lsp, workspace_workspaceFolders )
+{
+    TestInterface server;
+    u1 processed = false;
+    std::string id = "";
+    server.workspace_workspaceFolders( [&]( WorkspaceFoldersResult result ) {
+        EXPECT_STREQ( result.dump().c_str(), Data().dump().c_str() );
+        processed = true;
+    } );
+    server.flush( [&]( const Message& message ) {
+        const auto packet = libstdhl::Network::LSP::Packet( message );
+        id = static_cast< const RequestMessage& >( message ).id();
+    } );
+    ResponseMessage response = ( id );
+    response.setResult( WorkspaceFoldersResult() );
+    EXPECT_FALSE( processed );
+    response.process( server );
+    EXPECT_TRUE( processed );
+    EXPECT_STREQ( id.c_str(), "0" );
+}
+
 TEST( libstdhl_cpp_network_lsp, workspace_didChangeWorkspaceFolders )
 {
     TestInterface server;

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -375,20 +375,18 @@ TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
 
     u1 processed = false;
     const auto params = ShowMessageRequestParams( MessageType::Info, "Info Message" );
-    server.window_showMessageRequest( params, [&]( const ShowMessageRequestResult& result ) {
+    server.window_showMessageRequest( params, [&]( const ResponseMessage& response ) {
         processed = true;
+        ShowMessageRequestResult result( response.result() );
         EXPECT_STREQ( result[ Identifier::title ].get< std::string >().c_str(), "title" );
     } );
-
     std::string id = "";
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
         id = static_cast< const RequestMessage& >( message ).id();
     } );
-
     ResponseMessage response( id );
     response.setResult( MessageActionItem( std::string{ "title" } ) );
-
     EXPECT_FALSE( processed );
     response.process( server );
     EXPECT_TRUE( processed );
@@ -447,9 +445,11 @@ TEST( libstdhl_cpp_network_lsp, ID_increment )
     std::string id = "";
 
     // make first request
-    server.window_showMessageRequest(
-        ShowMessageRequestParams( MessageType::Info, "Message" ),
-        [&]( const ShowMessageRequestResult& result ) { messageRequestProcessed = true; } );
+    const auto params = ShowMessageRequestParams( MessageType::Info, "Info Message" );
+    server.window_showMessageRequest( params, [&]( const ResponseMessage& response ) {
+        messageRequestProcessed = true;
+        ShowMessageRequestResult result( response.result() );
+    } );
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
         id = static_cast< const RequestMessage& >( message ).id();

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -44,6 +44,7 @@
 
 #include <libstdhl/net/lsp/Identifier>
 #include <libstdhl/net/lsp/LSP>
+
 using namespace libstdhl;
 using namespace Network;
 using namespace LSP;
@@ -54,6 +55,11 @@ class TestInterface final : public ServerInterface
     TestInterface( void )
     {
     }
+
+    //
+    //
+    // Lifetime
+    //
 
     InitializeResult initialize( const InitializeParams& params ) override
     {
@@ -72,9 +78,30 @@ class TestInterface final : public ServerInterface
     void exit( void ) noexcept override
     {
     }
+
+    //
+    //
+    // Window
+    //
+
+    //
+    //
+    // Telemetry
+    //
+
+    //
+    //
+    // Client
+    //
+
     void client_cancel( const CancelParams& params ) noexcept override
     {
     }
+
+    //
+    //
+    // Workspace
+    //
 
     ExecuteCommandResult workspace_executeCommand( const ExecuteCommandParams& params ) override
     {
@@ -106,6 +133,11 @@ class TestInterface final : public ServerInterface
         return WorkspaceSymbolResult( info );
     }
 
+    //
+    //
+    // Text Synchronization
+    //
+
     void textDocument_didOpen( const DidOpenTextDocumentParams& params ) noexcept override
     {
     }
@@ -132,6 +164,16 @@ class TestInterface final : public ServerInterface
     void textDocument_didClose( const DidCloseTextDocumentParams& params ) noexcept override
     {
     }
+
+    //
+    //
+    // Diagnostics
+    //
+
+    //
+    //
+    // Language Features
+    //
 
     CompletionResult textDocument_completion( const CompletionParams& params ) override
     {
@@ -172,6 +214,7 @@ class TestInterface final : public ServerInterface
     {
         return CodeLensResult();
     }
+
     TypeDefinitionResult textDocument_typeDefinition( const TypeDefinitionParams& params ) override
     {
         return TypeDefinitionResult( Data() );
@@ -182,29 +225,35 @@ class TestInterface final : public ServerInterface
     {
         return TextDocumentImplementationResult( Data() );
     }
+
     ReferenceResult textDocument_references( const ReferenceParams& params ) override
     {
         return ReferenceResult( Data() );
     }
+
     DocumentHighlightResult textDocument_documentHighlight(
         const DocumentHighlightParams& params ) override
     {
         return DocumentHighlightResult();
     }
+
     DocumentSymbolResult textDocument_documentSymbol( const DocumentSymbolParams& params ) override
     {
         return DocumentSymbolResult();
     }
+
     CodeLensResolveResult codeLens_resolve( const CodeLensResolveParams& params ) override
     {
         auto start = Position( 1, 1 );
         auto end = Position( 1, 10 );
         return CodeLensResolveResult( Range( start, end ) );
     }
+
     DocumentLinkResult textDocument_documentLink( const DocumentLinkParams& params ) override
     {
         return DocumentLinkResult();
     }
+
     DocumentLinkResolveResult documentLink_resolve(
         const DocumentLinkResolveParams& params ) override
     {
@@ -212,38 +261,46 @@ class TestInterface final : public ServerInterface
         auto end = Position( 1, 10 );
         return DocumentLinkResolveResult( Range( start, end ) );
     }
+
     DocumentColorResult textDocument_documentColor( const DocumentColorParams& params ) override
     {
         return DocumentColorResult( ColorInformations() );
     }
+
     ColorPresentationResult textDocument_colorPresentation(
         const ColorPresentationParams& params ) override
     {
         return ColorPresentationResult( ColorPresentations() );
     }
+
     DocumentFormattingResult textDocument_formatting(
         const DocumentFormattingParams& params ) override
     {
         return DocumentFormattingResult();
     }
+
     DocumentRangeFormattingResult textDocument_rangeFormatting(
         const DocumentRangeFormattingParams& params ) override
     {
         return DocumentRangeFormattingResult();
     }
+
     DocumentOnTypeFormattingResult textDocument_onTypeFormatting(
         const DocumentOnTypeFormattingParams& params ) override
     {
         return DocumentOnTypeFormattingResult();
     }
+
     RenameResult textDocument_rename( const RenameParams& params ) override
     {
         return RenameResult();
     }
+
     PrepareRenameResult textDocument_prepareRename( const PrepareRenameParams& params ) override
     {
         return PrepareRenameResult();
     }
+
     FoldingRangeResult textDocument_foldingRange( const FoldingRangeParams& params ) override
     {
         return FoldingRangeResult();

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -375,13 +375,15 @@ TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
 
     u1 processed = false;
     const auto params = ShowMessageRequestParams( MessageType::Info, "Info Message" );
-    server.window_showMessageRequest(
-        params, [&]( const ShowMessageRequestResult& result ) { processed = true; } );
+    server.window_showMessageRequest( params, [&]( const ShowMessageRequestResult& result ) {
+        processed = true;
+        EXPECT_STREQ( result.title().c_str(), "title" );
+    } );
 
-    std::string id = "0";
+    std::string id = "";
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
-        // id = static_cast< const RequestMessage& >( message ).id();
+        id = static_cast< const RequestMessage& >( message ).id();
     } );
 
     ResponseMessage response( id );

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -560,8 +560,11 @@ TEST( libstdhl_cpp_network_lsp, workspace_configuration )
     auto items = std::vector< ConfigurationItem >();
     items.emplace_back( ConfigurationItem( "scope://Uri", "section" ) );
     server.workspace_configuration(
-        ConfigurationParams( items ),
-        [&]( const ConfigurationResult& result ) { processed = true; } );
+        ConfigurationParams( items ), [&]( const ResponseMessage& response ) {
+            processed = true;
+            ConfigurationResult result( response.result() );
+            EXPECT_EQ( result, Data::array() );
+        } );
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );
         id = static_cast< RequestMessage >( message ).id();

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -42,8 +42,8 @@
 
 #include <libstdhl/Test>
 
+#include <libstdhl/net/lsp/Identifier>
 #include <libstdhl/net/lsp/LSP>
-
 using namespace libstdhl;
 using namespace Network;
 using namespace LSP;
@@ -377,7 +377,7 @@ TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
     const auto params = ShowMessageRequestParams( MessageType::Info, "Info Message" );
     server.window_showMessageRequest( params, [&]( const ShowMessageRequestResult& result ) {
         processed = true;
-        EXPECT_STREQ( result.title().c_str(), "title" );
+        EXPECT_STREQ( result[ Identifier::title ].get< std::string >().c_str(), "title" );
     } );
 
     std::string id = "";

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -513,8 +513,9 @@ TEST( libstdhl_cpp_network_lsp, workspace_workspaceFolders )
     TestInterface server;
     u1 processed = false;
     std::string id = "";
-    server.workspace_workspaceFolders( [&]( WorkspaceFoldersResult result ) {
-        EXPECT_STREQ( result.dump().c_str(), Data().dump().c_str() );
+    server.workspace_workspaceFolders( [&]( const ResponseMessage& response ) {
+        WorkspaceFoldersResult result( response.result() );
+        EXPECT_EQ( result, WorkspaceFoldersResult() );
         processed = true;
     } );
     server.flush( [&]( const Message& message ) {

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -619,9 +619,10 @@ TEST( libstdhl_cpp_network_lsp, workspace_applyEdit )
     auto processed = false;
     std::string id = "";
     server.workspace_applyEdit(
-        ApplyWorkspaceEditParams( WorkspaceEdit() ), [&]( const ApplyWorkspaceEditResult& result ) {
+        ApplyWorkspaceEditParams( WorkspaceEdit() ), [&]( const ResponseMessage& response ) {
             processed = true;
-            EXPECT_TRUE( result.applied() );
+            ApplyWorkspaceEditResult result( response.result() );
+            EXPECT_EQ( result, ApplyWorkspaceEditResult( true ) );
         } );
     server.flush( [&]( const Message& message ) {
         const auto packet = libstdhl::Network::LSP::Packet( message );

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -42,17 +42,16 @@
 
 #include <libstdhl/Test>
 
-#include <libstdhl/net/lsp/Identifier>
 #include <libstdhl/net/lsp/LSP>
 
 using namespace libstdhl;
 using namespace Network;
 using namespace LSP;
 
-class TestInterface final : public ServerInterface
+class TestServer final : public Server
 {
   public:
-    TestInterface( void )
+    TestServer( void )
     {
     }
 
@@ -79,6 +78,10 @@ class TestInterface final : public ServerInterface
     {
     }
 
+    void client_cancel( const CancelParams& params ) noexcept override
+    {
+    }
+
     //
     //
     // Window
@@ -94,34 +97,10 @@ class TestInterface final : public ServerInterface
     // Client
     //
 
-    void client_cancel( const CancelParams& params ) noexcept override
-    {
-    }
-
     //
     //
     // Workspace
     //
-
-    ExecuteCommandResult workspace_executeCommand( const ExecuteCommandParams& params ) override
-    {
-        return ExecuteCommandResult();
-    }
-
-    void workspace_didChangeWorkspaceFolders(
-        const DidChangeWorkspaceFoldersParams& params ) noexcept override
-    {
-    }
-
-    void workspace_didChangeConfiguration(
-        const DidChangeConfigurationParams& params ) noexcept override
-    {
-    }
-
-    void workspace_didChangeWatchedFiles(
-        const DidChangeWatchedFilesParams& params ) noexcept override
-    {
-    }
 
     WorkspaceSymbolResult workspace_symbol( const WorkspaceSymbolParams& params ) override
     {
@@ -138,31 +117,11 @@ class TestInterface final : public ServerInterface
     // Text Synchronization
     //
 
-    void textDocument_didOpen( const DidOpenTextDocumentParams& params ) noexcept override
-    {
-    }
-
-    void textDocument_didChange( const DidChangeTextDocumentParams& params ) noexcept override
-    {
-    }
-
-    void textDocument_willSave( const WillSaveTextDocumentParams& params ) noexcept override
-    {
-    }
-
     WillSaveWaitUntilResponse textDocument_willSaveWaitUntil(
         const WillSaveTextDocumentParams& params ) override
     {
         auto result = std::vector< TextEdit >();
         return WillSaveWaitUntilResponse( result );
-    }
-
-    void textDocument_didSave( const DidSaveTextDocumentParams& params ) noexcept override
-    {
-    }
-
-    void textDocument_didClose( const DidCloseTextDocumentParams& params ) noexcept override
-    {
     }
 
     //
@@ -175,20 +134,9 @@ class TestInterface final : public ServerInterface
     // Language Features
     //
 
-    CompletionResult textDocument_completion( const CompletionParams& params ) override
-    {
-        auto items = std::vector< CompletionItem >();
-        return CompletionList( true, items );
-    }
-
     CompletionResolveResult completionItem_resolve( const CompletionParams& params ) override
     {
         return CompletionResolveResult( std::string( "label" ) );
-    }
-
-    HoverResult textDocument_hover( const HoverParams& params ) override
-    {
-        return HoverResult();
     }
 
     SignatureHelpResult textDocument_signatureHelp( const SignatureHelpParams& params ) override
@@ -205,53 +153,11 @@ class TestInterface final : public ServerInterface
         return DefinitionResult( Location( uri, range ) );
     }
 
-    CodeActionResult textDocument_codeAction( const CodeActionParams& params ) override
-    {
-        return CodeActionResult();
-    }
-
-    CodeLensResult textDocument_codeLens( const CodeLensParams& params ) override
-    {
-        return CodeLensResult();
-    }
-
-    TypeDefinitionResult textDocument_typeDefinition( const TypeDefinitionParams& params ) override
-    {
-        return TypeDefinitionResult( Data() );
-    }
-
-    TextDocumentImplementationResult textDocument_implementation(
-        const TextDocumentImplementationParams& params ) override
-    {
-        return TextDocumentImplementationResult( Data() );
-    }
-
-    ReferenceResult textDocument_references( const ReferenceParams& params ) override
-    {
-        return ReferenceResult( Data() );
-    }
-
-    DocumentHighlightResult textDocument_documentHighlight(
-        const DocumentHighlightParams& params ) override
-    {
-        return DocumentHighlightResult();
-    }
-
-    DocumentSymbolResult textDocument_documentSymbol( const DocumentSymbolParams& params ) override
-    {
-        return DocumentSymbolResult();
-    }
-
     CodeLensResolveResult codeLens_resolve( const CodeLensResolveParams& params ) override
     {
         auto start = Position( 1, 1 );
         auto end = Position( 1, 10 );
         return CodeLensResolveResult( Range( start, end ) );
-    }
-
-    DocumentLinkResult textDocument_documentLink( const DocumentLinkParams& params ) override
-    {
-        return DocumentLinkResult();
     }
 
     DocumentLinkResolveResult documentLink_resolve(
@@ -260,50 +166,6 @@ class TestInterface final : public ServerInterface
         auto start = Position( 1, 1 );
         auto end = Position( 1, 10 );
         return DocumentLinkResolveResult( Range( start, end ) );
-    }
-
-    DocumentColorResult textDocument_documentColor( const DocumentColorParams& params ) override
-    {
-        return DocumentColorResult( ColorInformations() );
-    }
-
-    ColorPresentationResult textDocument_colorPresentation(
-        const ColorPresentationParams& params ) override
-    {
-        return ColorPresentationResult( ColorPresentations() );
-    }
-
-    DocumentFormattingResult textDocument_formatting(
-        const DocumentFormattingParams& params ) override
-    {
-        return DocumentFormattingResult();
-    }
-
-    DocumentRangeFormattingResult textDocument_rangeFormatting(
-        const DocumentRangeFormattingParams& params ) override
-    {
-        return DocumentRangeFormattingResult();
-    }
-
-    DocumentOnTypeFormattingResult textDocument_onTypeFormatting(
-        const DocumentOnTypeFormattingParams& params ) override
-    {
-        return DocumentOnTypeFormattingResult();
-    }
-
-    RenameResult textDocument_rename( const RenameParams& params ) override
-    {
-        return RenameResult();
-    }
-
-    PrepareRenameResult textDocument_prepareRename( const PrepareRenameParams& params ) override
-    {
-        return PrepareRenameResult();
-    }
-
-    FoldingRangeResult textDocument_foldingRange( const FoldingRangeParams& params ) override
-    {
-        return FoldingRangeResult();
     }
 };
 
@@ -335,7 +197,7 @@ TEST( libstdhl_cpp_network_lsp, parse_packet_request_initialize_monaco )
 
     const auto request = libstdhl::Network::LSP::Packet::parse( req );
 
-    TestInterface server;
+    TestServer server;
 
     request.process( server );
 
@@ -394,7 +256,7 @@ TEST( libstdhl_cpp_network_lsp, parse_packet_request_initialize_vscode )
 
     const auto request = libstdhl::Network::LSP::Packet::parse( req );
 
-    TestInterface server;
+    TestServer server;
 
     request.process( server );
 
@@ -415,7 +277,7 @@ TEST( libstdhl_cpp_network_lsp, parse_packet_request_initialize_vscode )
 
 TEST( libstdhl_cpp_network_lsp, window_showMessage )
 {
-    TestInterface server;
+    TestServer server;
     server.window_showMessage( ShowMessageParams( MessageType::Error, "Error Message" ) );
     server.window_showMessage( ShowMessageParams( MessageType::Info, "Info Message" ) );
     server.window_showMessage( ShowMessageParams( MessageType::Log, "Log Message" ) );
@@ -428,7 +290,7 @@ TEST( libstdhl_cpp_network_lsp, window_showMessage )
 
 TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
 {
-    TestInterface server;
+    TestServer server;
 
     u1 processed = false;
     const auto params = ShowMessageRequestParams( MessageType::Info, "Info Message" );
@@ -451,7 +313,7 @@ TEST( libstdhl_cpp_network_lsp, window_showMessageRequest )
 
 TEST( libstdhl_cpp_network_lsp, window_logMessage )
 {
-    TestInterface server;
+    TestServer server;
     server.window_logMessage( LogMessageParams( MessageType::Error, "Error Message" ) );
     server.window_logMessage( LogMessageParams( MessageType::Info, "Info Message" ) );
     server.window_logMessage( LogMessageParams( MessageType::Log, "Log Message" ) );
@@ -464,7 +326,7 @@ TEST( libstdhl_cpp_network_lsp, window_logMessage )
 
 TEST( libstdhl_cpp_network_lsp, telemetry_event )
 {
-    TestInterface server;
+    TestServer server;
     server.telemetry_event( TelemetryEventParams( Data::object() ) );
 
     server.flush( [&]( const Message& response ) {
@@ -474,7 +336,7 @@ TEST( libstdhl_cpp_network_lsp, telemetry_event )
 
 TEST( libstdhl_cpp_network_lsp, client_registerCapability )
 {
-    TestInterface server;
+    TestServer server;
     u1 processed = false;
     Registration reg( "1", "test/method" );
     Registration reg2( "2", "test/method" );
@@ -501,7 +363,7 @@ TEST( libstdhl_cpp_network_lsp, client_registerCapability )
 
 TEST( libstdhl_cpp_network_lsp, ID_increment )
 {
-    TestInterface server;
+    TestServer server;
     u1 messageRequestProcessed = false;
     std::string id = "";
 
@@ -535,7 +397,7 @@ TEST( libstdhl_cpp_network_lsp, ID_increment )
 
 TEST( libstdhl_cpp_network_lsp, client_unregisterCapability )
 {
-    TestInterface server;
+    TestServer server;
     u1 processed = false;
     std::string id = "";
     Unregistration reg( "1", "test/method" );
@@ -560,7 +422,7 @@ TEST( libstdhl_cpp_network_lsp, client_unregisterCapability )
 
 TEST( libstdhl_cpp_network_lsp, workspace_workspaceFolders )
 {
-    TestInterface server;
+    TestServer server;
     u1 processed = false;
     std::string id = "";
     server.workspace_workspaceFolders( [&]( const ResponseMessage& response ) {
@@ -582,7 +444,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_workspaceFolders )
 
 TEST( libstdhl_cpp_network_lsp, workspace_didChangeWorkspaceFolders )
 {
-    TestInterface server;
+    TestServer server;
     auto added = std::vector< WorkspaceFolder >();
     added.emplace_back( WorkspaceFolder( "test://uri", "name" ) );
     auto removed = std::vector< WorkspaceFolder >();
@@ -595,7 +457,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_didChangeWorkspaceFolders )
 
 TEST( libstdhl_cpp_network_lsp, workspace_didChangeConfiguration )
 {
-    TestInterface server;
+    TestServer server;
     server.workspace_didChangeConfiguration( DidChangeConfigurationParams( Data::object() ) );
     server.flush( [&]( const Message& response ) {
         const auto packet = libstdhl::Network::LSP::Packet( response );
@@ -604,7 +466,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_didChangeConfiguration )
 
 TEST( libstdhl_cpp_network_lsp, workspace_configuration )
 {
-    TestInterface server;
+    TestServer server;
     u1 processed = false;
     std::string id = "";
     auto items = std::vector< ConfigurationItem >();
@@ -628,7 +490,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_configuration )
 
 TEST( libstdhl_cpp_network_lsp, workspace_didChangeWatchedFiles )
 {
-    TestInterface server;
+    TestServer server;
     auto events = std::vector< FileEvent >();
     auto empty = std::vector< FileEvent >();
     auto uri = DocumentUri::fromString( "file:///users/me/c-projects/" );
@@ -642,7 +504,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_didChangeWatchedFiles )
 
 TEST( libstdhl_cpp_network_lsp, workspace_symbol )
 {
-    TestInterface server;
+    TestServer server;
     auto result = server.workspace_symbol( WorkspaceSymbolParams( std::string( "query" ) ) );
 
     server.flush( [&]( const Message& response ) {
@@ -652,7 +514,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_symbol )
 
 TEST( libstdhl_cpp_network_lsp, workspace_executeCommand )
 {
-    TestInterface server;
+    TestServer server;
     auto params = ExecuteCommandParams( std::string( "Command" ) );
     params.addArgument( Data::object() );
     EXPECT_TRUE( params.hasArguments() );
@@ -665,7 +527,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_executeCommand )
 
 TEST( libstdhl_cpp_network_lsp, workspace_applyEdit )
 {
-    TestInterface server;
+    TestServer server;
     auto processed = false;
     std::string id = "";
     server.workspace_applyEdit(
@@ -687,7 +549,7 @@ TEST( libstdhl_cpp_network_lsp, workspace_applyEdit )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_willSave )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     server.textDocument_willSave(
         WillSaveTextDocumentParams( document, TextDocumentSaveReason::AfterDelay ) );
@@ -699,7 +561,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_willSave )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_didSave )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = DidSaveTextDocumentParams( document );
     EXPECT_FALSE( params.hasText() );
@@ -714,7 +576,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_didSave )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_didClose )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = DidCloseTextDocumentParams( document );
     server.textDocument_didClose( params );
@@ -726,7 +588,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_didClose )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_signatureHelp )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = TextDocumentPositionParams( document, Position( 10, 10 ) );
     auto result = server.textDocument_signatureHelp( params );
@@ -737,7 +599,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_signatureHelp )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_definition )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = TextDocumentPositionParams( document, Position( 10, 10 ) );
     auto result = server.textDocument_definition( params );
@@ -748,7 +610,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_definition )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_completion )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = CompletionParams( document, Position( 1, 10 ) );
     auto result = server.textDocument_completion( params );
@@ -759,7 +621,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_completion )
 
 TEST( libstdhl_cpp_network_lsp, completionItem_resolve )
 {
-    TestInterface server;
+    TestServer server;
     auto document = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto params = CompletionParams( document, Position( 1, 10 ) );
     auto result = server.completionItem_resolve( params );
@@ -770,25 +632,27 @@ TEST( libstdhl_cpp_network_lsp, completionItem_resolve )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_typeDefinition )
 {
-    TestInterface server;
+    TestServer server;
     auto result = server.textDocument_typeDefinition( TextDocumentPositionParams(
         TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) ), Position( 1, 1 ) ) );
     server.flush( [&]( const Message& response ) {
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 TEST( libstdhl_cpp_network_lsp, textDocument_implementation )
 {
-    TestInterface server;
+    TestServer server;
     auto result = server.textDocument_implementation( TextDocumentPositionParams(
         TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) ), Position( 1, 1 ) ) );
     server.flush( [&]( const Message& response ) {
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 TEST( libstdhl_cpp_network_lsp, textDocument_references )
 {
-    TestInterface server;
+    TestServer server;
     auto uri = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto pos = Position( 1, 1 );
     auto result =
@@ -800,7 +664,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_references )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_documentHighlight )
 {
-    TestInterface server;
+    TestServer server;
     auto uri = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto pos = Position( 1, 1 );
     auto result = server.textDocument_documentHighlight( DocumentHighlightParams( uri, pos ) );
@@ -811,7 +675,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_documentHighlight )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_documentSymbol )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto result = server.textDocument_documentSymbol( DocumentSymbolParams( doc ) );
     server.flush( [&]( const Message& response ) {
@@ -821,7 +685,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_documentSymbol )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_codeAction )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto range = Range( Position( 10, 10 ), Position( 10, 10 ) );
     auto result = server.textDocument_codeAction(
@@ -833,7 +697,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_codeAction )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_codeLens )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto result = server.textDocument_codeLens( CodeLensParams( doc ) );
     server.flush( [&]( const Message& response ) {
@@ -843,7 +707,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_codeLens )
 
 TEST( libstdhl_cpp_network_lsp, codeLens_resolve )
 {
-    TestInterface server;
+    TestServer server;
     auto start = Position( 1, 1 );
     auto end = Position( 1, 10 );
     auto result = server.codeLens_resolve( CodeLensResolveParams( Range( start, end ) ) );
@@ -854,7 +718,7 @@ TEST( libstdhl_cpp_network_lsp, codeLens_resolve )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_documentLink )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto result = server.textDocument_documentLink( DocumentLinkParams( doc ) );
     server.flush( [&]( const Message& response ) {
@@ -864,7 +728,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_documentLink )
 
 TEST( libstdhl_cpp_network_lsp, documentLink_resolve )
 {
-    TestInterface server;
+    TestServer server;
     auto start = Position( 1, 1 );
     auto end = Position( 1, 10 );
     auto result = server.documentLink_resolve( DocumentLinkResolveParams( Range( start, end ) ) );
@@ -875,16 +739,17 @@ TEST( libstdhl_cpp_network_lsp, documentLink_resolve )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_documentColor )
 {
-    TestInterface server;
+    TestServer server;
     auto result = server.textDocument_documentColor(
         DocumentColorParams( TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) ) ) );
     server.flush( [&]( const Message& response ) {
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 TEST( libstdhl_cpp_network_lsp, textDocument_colorPresentation )
 {
-    TestInterface server;
+    TestServer server;
     auto start = Position( 1, 1 );
     auto end = Position( 1, 10 );
     auto range = Range( start, end );
@@ -896,9 +761,10 @@ TEST( libstdhl_cpp_network_lsp, textDocument_colorPresentation )
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 TEST( libstdhl_cpp_network_lsp, textDocument_formatting )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto options = FormattingOptions( 2, true );
     auto result = server.textDocument_formatting( DocumentFormattingParams( doc, options ) );
@@ -909,7 +775,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_formatting )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_rangeFormatting )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto options = FormattingOptions( 2, true );
     auto start = Position( 1, 1 );
@@ -924,7 +790,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_rangeFormatting )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_onTypeFormatting )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto options = FormattingOptions( 2, true );
     auto start = Position( 1, 1 );
@@ -937,7 +803,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_onTypeFormatting )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_rename )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto start = Position( 1, 1 );
     auto result = server.textDocument_rename( RenameParams( doc, start, "newName" ) );
@@ -948,7 +814,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_rename )
 
 TEST( libstdhl_cpp_network_lsp, textDocument_prepareRename )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto start = Position( 1, 1 );
     auto result = server.textDocument_prepareRename( PrepareRenameParams( doc, start ) );
@@ -956,9 +822,10 @@ TEST( libstdhl_cpp_network_lsp, textDocument_prepareRename )
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 TEST( libstdhl_cpp_network_lsp, textDocument_foldingRange )
 {
-    TestInterface server;
+    TestServer server;
     auto doc = TextDocumentIdentifier( DocumentUri::fromString( "test://uri" ) );
     auto start = Position( 1, 1 );
     auto result = server.textDocument_foldingRange( FoldingRangeParams( doc ) );
@@ -966,6 +833,7 @@ TEST( libstdhl_cpp_network_lsp, textDocument_foldingRange )
         const auto packet = libstdhl::Network::LSP::Packet( response );
     } );
 }
+
 //
 //  Local variables:
 //  mode: c++

--- a/etc/test/cpp/net/lsp/interface.cpp
+++ b/etc/test/cpp/net/lsp/interface.cpp
@@ -153,7 +153,7 @@ class TestInterface final : public ServerInterface
     {
         auto info = std::vector< SignatureInformation >();
         info.push_back( SignatureInformation( std::string( "label" ) ) );
-        return SignatureHelpResult( info );
+        return SignatureHelpResult( SignatureHelp( info ) );
     }
 
     DefinitionResult textDocument_definition( const DefinitionParams& params ) override

--- a/etc/test/cpp/random.cpp
+++ b/etc/test/cpp/random.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/std/rfc3986.cpp
+++ b/etc/test/cpp/std/rfc3986.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/string.cpp
+++ b/etc/test/cpp/string.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/type.cpp
+++ b/etc/test/cpp/type.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/variadic.cpp
+++ b/etc/test/cpp/variadic.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/cpp/xml.cpp
+++ b/etc/test/cpp/xml.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/etc/test/main.cpp
+++ b/etc/test/main.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/src/c/args.c
+++ b/src/c/args.c
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/c/args.h
+++ b/src/c/args.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/c/default.h
+++ b/src/c/default.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/c/math.h
+++ b/src/c/math.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/c/type.h
+++ b/src/c/type.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Allocator.h
+++ b/src/cpp/Allocator.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Ansi.cpp
+++ b/src/cpp/Ansi.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Ansi.h
+++ b/src/cpp/Ansi.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Args.cpp
+++ b/src/cpp/Args.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Args.h
+++ b/src/cpp/Args.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Array.h
+++ b/src/cpp/Array.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Binding.h
+++ b/src/cpp/Binding.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library( ${PROJECT}-cpp OBJECT
   net/lsp/Message.cpp
   net/lsp/Packet.cpp
   net/lsp/Protocol.cpp
+  net/lsp/Server.cpp
   net/tcp/IPv4.cpp
   net/tcp/Socket.cpp
   net/udp/IPv4.cpp
@@ -322,6 +323,7 @@ ecm_generate_headers( ${PROJECT}_NET_LSP_HEADERS_CPP
     Message
     Packet
     Protocol
+    Server
   PREFIX
     ${PROJECT}/net/lsp
   RELATIVE

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library( ${PROJECT}-cpp OBJECT
   Environment.cpp
   Exception.cpp
   File.cpp
+  Json.cpp
   SourceLocation.cpp
   data/file/TextDocument.cpp
   data/log/Category.cpp

--- a/src/cpp/Enum.h
+++ b/src/cpp/Enum.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Environment.cpp
+++ b/src/cpp/Environment.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Environment.h
+++ b/src/cpp/Environment.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Exception.cpp
+++ b/src/cpp/Exception.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Exception.h
+++ b/src/cpp/Exception.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/File.h
+++ b/src/cpp/File.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Hash.h
+++ b/src/cpp/Hash.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Json.cpp
+++ b/src/cpp/Json.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2014-2018 CASM Organization <https://casm-lang.org>
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
 //  All rights reserved.
 //
 //  Developed by: Philipp Paulweber

--- a/src/cpp/Json.cpp
+++ b/src/cpp/Json.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Json.cpp
+++ b/src/cpp/Json.cpp
@@ -1,0 +1,202 @@
+//
+//  Copyright (C) 2014-2018 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libstdhl>
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libstdhl is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libstdhl
+//  statically or dynamically with other modules is making a combined work
+//  based on libstdhl. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libstdhl give you permission to link libstdhl
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libstdhl. If you modify libstdhl, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#include "Json.h"
+
+using namespace libstdhl;
+
+u1 Json::hasProperty( const Object& object, const std::string& field )
+{
+    return object.find( field ) != object.end();
+}
+
+void Json::validateTypeIsObject( const std::string& context, const Object& object )
+{
+    if( not object.is_object() )
+    {
+        throw std::invalid_argument( context + " invalid data type, shall be 'object'" );
+    }
+}
+
+void Json::validateTypeIsString( const std::string& context, const Object& object )
+{
+    if( not object.is_string() )
+    {
+        throw std::invalid_argument( context + " invalid data type, shall be 'string'" );
+    }
+}
+
+void Json::validateTypeIsArray( const std::string& context, const Object& object )
+{
+    if( not object.is_array() )
+    {
+        throw std::invalid_argument( context + " invalid data type, shall be 'array'" );
+    }
+}
+
+void Json::validatePropertyIs(
+    const std::string& context,
+    const Object& object,
+    const std::string& field,
+    const u1 required,
+    const std::function< u1( const Object& property ) >& condition )
+{
+    if( hasProperty( object, field ) )
+    {
+        if( not condition( object[ field ] ) )
+        {
+            throw std::invalid_argument( context + " invalid property '" + field + "'" );
+        }
+    }
+    else
+    {
+        if( required )
+        {
+            throw std::invalid_argument( context + " missing property '" + field + "'" );
+        }
+    }
+}
+
+void Json::validatePropertyIsObject(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_object();
+    } );
+}
+
+void Json::validatePropertyIsArray(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_array();
+    } );
+}
+
+void Json::validatePropertyIsString(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_string();
+    } );
+}
+
+void Json::validatePropertyIsNumber(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_number();
+    } );
+}
+
+void Json::validatePropertyIsNumberOrNull(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_number() or property.is_null();
+    } );
+}
+
+void Json::validatePropertyIsBoolean(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_boolean();
+    } );
+}
+
+void Json::validatePropertyIsUuid(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_string() or property.is_number();
+    } );
+}
+
+void Json::validatePropertyIsUri(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIsString( context, object, field, required );
+    try
+    {
+        libstdhl::Standard::RFC3986::URI::fromString( object[ field ].get< std::string >() );
+    }
+    catch( const std::exception& e )
+    {
+        throw std::invalid_argument( context + " DocumentUri: " + e.what() );
+    }
+}
+
+void Json::validatePropertyIsUriOrNull(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIs( context, object, field, required, []( const Object& property ) -> u1 {
+        return property.is_string() or property.is_null();
+    } );
+    if( hasProperty( object, field ) and object[ field ].is_string() )
+    {
+        validatePropertyIsUri( context, object, field, required );
+    }
+}
+
+void Json::validatePropertyIsArrayOfString(
+    const std::string& context, const Object& object, const std::string& field, const u1 required )
+{
+    validatePropertyIsArray( context, object, field, required );
+    if( hasProperty( object, field ) )
+    {
+        for( auto element : object[ field ] )
+        {
+            validateTypeIsString( context, element );
+        }
+    }
+}
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/cpp/Json.h
+++ b/src/cpp/Json.h
@@ -44,6 +44,8 @@
 #ifndef _LIBSTDHL_CPP_JSON_H_
 #define _LIBSTDHL_CPP_JSON_H_
 
+#include <libstdhl/Type>
+#include <libstdhl/std/rfc3986>
 #include <libstdhl/vendor/json/json>
 
 /**
@@ -60,6 +62,152 @@ namespace libstdhl
     namespace Json
     {
         using Object = nlohmann::json;
+
+        u1 hasProperty( const Object& object, const std::string& field );
+
+        void validateTypeIsObject( const std::string& context, const Object& object );
+
+        void validateTypeIsString( const std::string& context, const Object& object );
+
+        void validateTypeIsArray( const std::string& context, const Object& object );
+
+        void validatePropertyIs(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required,
+            const std::function< u1( const Object& property ) >& condition );
+
+        void validatePropertyIsObject(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsArray(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsString(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsNumber(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsNumberOrNull(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsBoolean(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsUuid(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsUri(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        void validatePropertyIsUriOrNull(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        template < class T >
+        void validatePropertyIs(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required )
+        {
+            validatePropertyIs(
+                context, object, field, required, []( const Object& property ) -> u1 {
+                    T::validate( property );
+                    return true;
+                } );
+        };
+
+        template < class T >
+        void validatePropertyIsArrayOf(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required )
+        {
+            validatePropertyIsArray( context, object, field, required );
+            if( hasProperty( object, field ) )
+            {
+                for( auto element : object[ field ] )
+                {
+                    T::validate( element );
+                }
+            }
+        };
+
+        void validatePropertyIsArrayOfString(
+            const std::string& context,
+            const Object& object,
+            const std::string& field,
+            const u1 required );
+
+        template < class T >
+        void validateTypeIsArrayOf( const std::string& context, const Object& object )
+        {
+            validateTypeIsArray( context, object );
+            for( auto element : object )
+            {
+                T::validate( element );
+            }
+        };
+
+        template < class T, class U >
+        void validateTypeIsMixedArrayOf( const std::string& context, const Data& data )
+        {
+            Content::validateTypeIsArray( context, data );
+            for( auto element : data )
+            {
+                try
+                {
+                    T::validate( element );
+                }
+                catch( std::invalid_argument a )
+                {
+                    U::validate( element );
+                }
+            }
+        };
+
+        template < class T, class U >
+        void validateTypeIsArrayOf( const std::string& context, const Data& data )
+        {
+            try
+            {
+                validateTypeIsArrayOf< T >( context, data );
+            }
+            catch( std::invalid_argument a )
+            {
+                validateTypeIsArrayOf< U >( context, data );
+            }
+        };
     };
 }
 

--- a/src/cpp/Json.h
+++ b/src/cpp/Json.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Json.h
+++ b/src/cpp/Json.h
@@ -180,10 +180,10 @@ namespace libstdhl
         };
 
         template < class T, class U >
-        void validateTypeIsMixedArrayOf( const std::string& context, const Data& data )
+        void validateTypeIsMixedArrayOf( const std::string& context, const Object& object )
         {
-            Content::validateTypeIsArray( context, data );
-            for( auto element : data )
+            validateTypeIsArray( context, object );
+            for( auto element : object )
             {
                 try
                 {
@@ -197,15 +197,15 @@ namespace libstdhl
         };
 
         template < class T, class U >
-        void validateTypeIsArrayOf( const std::string& context, const Data& data )
+        void validateTypeIsArrayOf( const std::string& context, const Object& object )
         {
             try
             {
-                validateTypeIsArrayOf< T >( context, data );
+                validateTypeIsArrayOf< T >( context, object );
             }
             catch( std::invalid_argument a )
             {
-                validateTypeIsArrayOf< U >( context, data );
+                validateTypeIsArrayOf< U >( context, object );
             }
         };
     };

--- a/src/cpp/Labeling.h
+++ b/src/cpp/Labeling.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Limits.h
+++ b/src/cpp/Limits.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/List.h
+++ b/src/cpp/List.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Log.h
+++ b/src/cpp/Log.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Math.h
+++ b/src/cpp/Math.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Memory.h
+++ b/src/cpp/Memory.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Network.h
+++ b/src/cpp/Network.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Optional.h
+++ b/src/cpp/Optional.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Random.h
+++ b/src/cpp/Random.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Standard.h
+++ b/src/cpp/Standard.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/String.h
+++ b/src/cpp/String.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Test.h
+++ b/src/cpp/Test.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Type.h
+++ b/src/cpp/Type.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Variadic.h
+++ b/src/cpp/Variadic.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Version.in.h
+++ b/src/cpp/Version.in.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/Xml.h
+++ b/src/cpp/Xml.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/file/TextDocument.cpp
+++ b/src/cpp/data/file/TextDocument.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/file/TextDocument.h
+++ b/src/cpp/data/file/TextDocument.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Category.cpp
+++ b/src/cpp/data/log/Category.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Category.h
+++ b/src/cpp/data/log/Category.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Channel.h
+++ b/src/cpp/data/log/Channel.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Chronograph.cpp
+++ b/src/cpp/data/log/Chronograph.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Chronograph.h
+++ b/src/cpp/data/log/Chronograph.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Data.cpp
+++ b/src/cpp/data/log/Data.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Data.h
+++ b/src/cpp/data/log/Data.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Filter.cpp
+++ b/src/cpp/data/log/Filter.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Filter.h
+++ b/src/cpp/data/log/Filter.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Formatter.cpp
+++ b/src/cpp/data/log/Formatter.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Formatter.h
+++ b/src/cpp/data/log/Formatter.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Item.cpp
+++ b/src/cpp/data/log/Item.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Item.h
+++ b/src/cpp/data/log/Item.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Level.cpp
+++ b/src/cpp/data/log/Level.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Level.h
+++ b/src/cpp/data/log/Level.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Logger.cpp
+++ b/src/cpp/data/log/Logger.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Logger.h
+++ b/src/cpp/data/log/Logger.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Router.cpp
+++ b/src/cpp/data/log/Router.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Router.h
+++ b/src/cpp/data/log/Router.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Sink.cpp
+++ b/src/cpp/data/log/Sink.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Sink.h
+++ b/src/cpp/data/log/Sink.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Source.cpp
+++ b/src/cpp/data/log/Source.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Source.h
+++ b/src/cpp/data/log/Source.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Stream.cpp
+++ b/src/cpp/data/log/Stream.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Stream.h
+++ b/src/cpp/data/log/Stream.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Switch.cpp
+++ b/src/cpp/data/log/Switch.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Switch.h
+++ b/src/cpp/data/log/Switch.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Timestamp.cpp
+++ b/src/cpp/data/log/Timestamp.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/log/Timestamp.h
+++ b/src/cpp/data/log/Timestamp.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Boolean.cpp
+++ b/src/cpp/data/type/Boolean.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Boolean.h
+++ b/src/cpp/data/type/Boolean.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Data.cpp
+++ b/src/cpp/data/type/Data.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Data.h
+++ b/src/cpp/data/type/Data.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Decimal.cpp
+++ b/src/cpp/data/type/Decimal.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Decimal.h
+++ b/src/cpp/data/type/Decimal.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Integer.cpp
+++ b/src/cpp/data/type/Integer.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Integer.h
+++ b/src/cpp/data/type/Integer.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Layout.h
+++ b/src/cpp/data/type/Layout.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Natural.cpp
+++ b/src/cpp/data/type/Natural.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Natural.h
+++ b/src/cpp/data/type/Natural.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Rational.cpp
+++ b/src/cpp/data/type/Rational.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/Rational.h
+++ b/src/cpp/data/type/Rational.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/String.cpp
+++ b/src/cpp/data/type/String.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/data/type/String.h
+++ b/src/cpp/data/type/String.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/libstdhl.h
+++ b/src/cpp/libstdhl.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/Interface.h
+++ b/src/cpp/net/Interface.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/Packet.cpp
+++ b/src/cpp/net/Packet.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/Packet.h
+++ b/src/cpp/net/Packet.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/Protocol.h
+++ b/src/cpp/net/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/Socket.h
+++ b/src/cpp/net/Socket.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Frame.cpp
+++ b/src/cpp/net/eth/Frame.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Frame.h
+++ b/src/cpp/net/eth/Frame.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Link.cpp
+++ b/src/cpp/net/eth/Link.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Link.h
+++ b/src/cpp/net/eth/Link.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Protocol.cpp
+++ b/src/cpp/net/eth/Protocol.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Protocol.h
+++ b/src/cpp/net/eth/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Socket.cpp
+++ b/src/cpp/net/eth/Socket.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/eth/Socket.h
+++ b/src/cpp/net/eth/Socket.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/ip4/Protocol.h
+++ b/src/cpp/net/ip4/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -7224,7 +7224,7 @@ Position DocumentOnTypeFormattingParams::position( void ) const
     return operator[]( Identifier::position );
 }
 
-std::string DocumentOnTypeFormattingParams::ch( void ) const
+std::string DocumentOnTypeFormattingParams::character( void ) const
 {
     return operator[]( Identifier::ch ).get< std::string >();
 }

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2194,6 +2194,81 @@ void ExecuteCommandOptions::validate( const Data& data )
 
 //
 //
+// StaticRegistrationOptions
+//
+StaticRegistrationOptions::StaticRegistrationOptions( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 StaticRegistrationOptions::hasId( void ) const
+{
+    return find( Identifier::id ) != end();
+}
+
+std::string StaticRegistrationOptions::id( void ) const
+{
+    return at( Identifier::id ).get< std::string >();
+}
+
+void StaticRegistrationOptions::setId( std::string id )
+{
+    operator[]( Identifier::id ) = id;
+}
+
+void StaticRegistrationOptions::validate( const Data& data )
+{
+    static const auto context = CONTENT + " StaticRegistrationOptions:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsString( context, data, Identifier::id, false );
+}
+
+//
+//
+// TypeDefinitionProvider
+//
+TypeDefinitionProvider::TypeDefinitionProvider( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 TypeDefinitionProvider::hasId( void ) const
+{
+    return find( Identifier::id ) != end();
+}
+
+std::string TypeDefinitionProvider::id( void ) const
+{
+    return at( Identifier::id ).get< std::string >();
+}
+
+void TypeDefinitionProvider::setId( std::string id )
+{
+    operator[]( Identifier::id ) = id;
+}
+
+DocumentSelector TypeDefinitionProvider::documentSelector( void ) const
+{
+    return operator[]( Identifier::documentSelector );
+}
+
+void TypeDefinitionProvider::validate( const Data& data )
+{
+    static const auto context = CONTENT + " TypeDefinitionProvider:";
+    if( data.is_boolean() )
+    {
+        // ok, do nothing
+    }
+    else
+    {
+        TextDocumentRegistrationOptions::validate( data );
+        StaticRegistrationOptions::validate( data );
+    }
+}
+//
+//
 // ServerCapabilities
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2518,6 +2518,44 @@ void MessageActionItem::validate( const Data& data )
 
 //
 //
+// ShowMessageRequestResult
+//
+
+ShowMessageRequestResult::ShowMessageRequestResult( void )
+: Data()
+{
+}
+ShowMessageRequestResult::ShowMessageRequestResult( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+ShowMessageRequestResult::ShowMessageRequestResult( const MessageActionItem& item )
+: Data( item )
+{
+}
+
+ShowMessageRequestResult::ShowMessageRequestResult( const std::string& title )
+: Data( Data::object() )
+{
+    operator[]( Identifier::title ) = title;
+}
+
+void ShowMessageRequestResult::validate( const Data& data )
+{
+    static const auto context = CONTENT + " ShowMessageRequestResult:";
+    if( data.is_null() )
+    {
+        // ok, do nothing.
+    }
+    else
+    {
+        MessageActionItem::validate( data );
+    }
+}
+//
+//
 // ShowMessageRequestParams
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -4642,7 +4642,37 @@ void SignatureHelp::validate( const Data& data )
     Content::validatePropertyIsNumber( context, data, Identifier::activeSignature, false );
     Content::validatePropertyIsNumber( context, data, Identifier::activeParameter, false );
 }
+//
+//
+// SignatureHelpResult
+//
+SignatureHelpResult::SignatureHelpResult( void )
+: Data( Data() )
+{
+}
 
+SignatureHelpResult::SignatureHelpResult( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+SignatureHelpResult::SignatureHelpResult( const SignatureHelp& signature )
+: Data( Data::from_cbor( Data::to_cbor( signature ) ) )
+{
+}
+
+void SignatureHelpResult::validate( const Data& data )
+{
+    if( data.is_null() )
+    {
+        // ok, do nothing
+    }
+    else
+    {
+        SignatureHelp::validate( data );
+    }
+}
 //
 //
 // TextDocumentSaveRegistrationOptions

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -5513,10 +5513,34 @@ void HoverResult::setRange( const Range& range )
 
 void HoverResult::validate( const Data& data )
 {
-    static const auto context = CONTENT + " HoverResult:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< MarkedString >( context, data, Identifier::contents, true );
-    Content::validatePropertyIsString( context, data, Identifier::value, true );
+    if( data.is_null() )
+    {
+        // ok, do nothing.
+    }
+    else
+    {
+        static const auto context = CONTENT + " HoverResult:";
+        Content::validateTypeIsObject( context, data );
+        try
+        {
+            Content::validatePropertyIs< MarkedString >(
+                context, data, Identifier::contents, true );
+        }
+        catch( std::invalid_argument a )
+        {
+            try
+            {
+                Content::validatePropertyIs< MarkupContent >(
+                    context, data, Identifier::contents, true );
+            }
+            catch( std::invalid_argument a )
+            {
+                Content::validatePropertyIsArrayOf< MarkedString >(
+                    context, data, Identifier::contents, true );
+            }
+        }
+        Content::validatePropertyIs< Range >( context, data, Identifier::range, false );
+    }
 }
 
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -4849,7 +4849,7 @@ TypeDefinitionResult::TypeDefinitionResult( const Data& data )
     validate( data );
 }
 
-TypeDefinitionResult::TypeDefinitionResult( const Locations locations )
+TypeDefinitionResult::TypeDefinitionResult( const Locations& locations )
 : Data( Data::array() )
 {
     for( auto location : locations )
@@ -4858,7 +4858,16 @@ TypeDefinitionResult::TypeDefinitionResult( const Locations locations )
     }
 }
 
-TypeDefinitionResult::TypeDefinitionResult( const Location location )
+TypeDefinitionResult::TypeDefinitionResult( const LocationLinks& locationlinks )
+: Data( Data::array() )
+{
+    for( auto link : locationlinks )
+    {
+        push_back( link );
+    }
+}
+
+TypeDefinitionResult::TypeDefinitionResult( const Location& location )
 {
     *this = Data::from_cbor( Data::to_cbor( location ) );
 }
@@ -4875,7 +4884,7 @@ void TypeDefinitionResult::validate( const Data& data )
     {
         if( data.is_array() )
         {
-            Content::validateTypeIsArrayOf< Location >( context, data );
+            Content::validateTypeIsArrayOf< Location, LocationLink >( context, data );
         }
         else
         {

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2408,6 +2408,51 @@ void InitializeError::validate( const Data& data )
 
 //
 //
+// CancelParams
+//
+CancelParams::CancelParams( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+CancelParams::CancelParams( const std::size_t& id )
+: Data( Data::object() )
+{
+    operator[]( Identifier::id ) = id;
+}
+
+CancelParams::CancelParams( const std::string& id )
+: Data( Data::object() )
+{
+    operator[]( Identifier::id ) = id;
+}
+std::string CancelParams::id( void ) const
+{
+    std::string result;
+    if( operator[]( Identifier::id ).is_number() )
+    {
+        return std::to_string( operator[]( Identifier::id ).get< std::size_t >() );
+    }
+    return operator[]( Identifier::id ).get< std::string >();
+}
+
+void CancelParams::validate( const Data& data )
+{
+    static const auto context = CONTENT + " CancelParams:";
+    Content::validateTypeIsObject( context, data );
+    if( data[ Identifier::id ].is_number() )
+    {
+        Content::validatePropertyIsNumber( context, data, Identifier::id, true );
+    }
+    else
+    {
+        Content::validatePropertyIsString( context, data, Identifier::id, true );
+    }
+}
+
+//
+//
 // ShowMessageParams
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -4675,6 +4675,72 @@ void SignatureHelpResult::validate( const Data& data )
 }
 //
 //
+// LocationLink
+//
+LocationLink::LocationLink( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+LocationLink::LocationLink( const DocumentUri& targetUri, const Range& targetRange )
+: Data( Data::object() )
+{
+    operator[]( Identifier::targetUri ) = targetUri.toString();
+    operator[]( Identifier::targetRange ) = Data::from_cbor( Data::to_cbor( targetRange ) );
+}
+
+DocumentUri LocationLink::targetUri( void ) const
+{
+    return DocumentUri::fromString( operator[]( Identifier::targetUri ).get< std::string >() );
+}
+
+Range LocationLink::targetRange( void ) const
+{
+    return operator[]( Identifier::targetRange );
+}
+
+u1 LocationLink::hasOriginSelectionRange( void ) const
+{
+    return find( Identifier::originSelectionRange ) != end();
+}
+
+void LocationLink::setOriginSelectionRange( const Range& range )
+{
+    operator[]( Identifier::originSelectionRange ) = Data::from_cbor( Data::to_cbor( range ) );
+}
+
+Range LocationLink::originSelectionRange( void ) const
+{
+    return operator[]( Identifier::originSelectionRange );
+}
+
+u1 LocationLink::hasTargetSelectionRange( void ) const
+{
+    return find( Identifier::targetSelectionRange ) != end();
+}
+
+void LocationLink::setTargetSelectionRange( const Range& range )
+{
+    operator[]( Identifier::targetSelectionRange ) = Data::from_cbor( Data::to_cbor( range ) );
+}
+
+Range LocationLink::targetSelectionRange( void ) const
+{
+    return operator[]( Identifier::targetSelectionRange );
+}
+
+void LocationLink::validate( const Data& data )
+{
+    static const auto context = CONTENT + " LocationLink:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsString( context, data, Identifier::targetUri, true );
+    Content::validatePropertyIs< Range >( context, data, Identifier::targetRange, true );
+    Content::validatePropertyIs< Range >( context, data, Identifier::originSelectionRange, false );
+    Content::validatePropertyIs< Range >( context, data, Identifier::targetSelectionRange, false );
+}
+//
+//
 // TextDocumentSaveRegistrationOptions
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2909,11 +2909,12 @@ void WorkspaceFolder::validate( const Data& data )
 //
 
 WorkspaceFoldersResult::WorkspaceFoldersResult()
-: Data( Data::array() )
+: Data( Data() )
 {
 }
 
 WorkspaceFoldersResult::WorkspaceFoldersResult( const Data& data )
+: Data( data )
 {
     validate( data );
 }

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -220,7 +220,7 @@ void Location::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsUri( context, data, Identifier::uri, true );
     Json::validatePropertyIs< Range >( context, data, Identifier::range, false );
-} 
+}
 
 //
 //
@@ -257,7 +257,7 @@ void DiagnosticRelatedInformation::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< Location >( context, data, Identifier::location, true );
     Json::validatePropertyIsString( context, data, Identifier::message, true );
-} 
+}
 
 //
 //
@@ -631,7 +631,7 @@ void CreateFileOptions::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
     Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
-} 
+}
 
 //
 //
@@ -742,7 +742,7 @@ void RenameFile::validate( const Data& data )
     Json::validatePropertyIsString( context, data, Identifier::newUri, true );
     Json::validatePropertyIsString( context, data, Identifier::oldUri, true );
     Json::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
-} 
+}
 
 //
 //
@@ -791,7 +791,7 @@ void DeleteFileOptions::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
     Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
-} 
+}
 
 //
 //
@@ -3599,7 +3599,7 @@ void WorkspaceFoldersChangeEvent::validate( const Data& data )
 
     Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::added, true );
     Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::removed, true );
-} 
+}
 
 //
 //
@@ -4095,7 +4095,7 @@ void WorkspaceSymbolResult::validate( const Data& data )
     {
         Json::validateTypeIsArrayOf< SymbolInformation >( context, data );
     }
-} 
+}
 
 //
 //
@@ -4881,7 +4881,7 @@ void CompletionList::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsArrayOf< CompletionItem >( context, data, Identifier::items, true );
     Json::validatePropertyIsBoolean( context, data, Identifier::isIncomplete, true );
-} 
+}
 
 //
 //
@@ -5239,7 +5239,7 @@ void SignatureHelp::validate( const Data& data )
         context, data, Identifier::signatures, true );
     Json::validatePropertyIsNumber( context, data, Identifier::activeSignature, false );
     Json::validatePropertyIsNumber( context, data, Identifier::activeParameter, false );
-} 
+}
 
 //
 //
@@ -5272,7 +5272,7 @@ void SignatureHelpResult::validate( const Data& data )
     {
         SignatureHelp::validate( data );
     }
-} 
+}
 
 //
 //
@@ -5340,7 +5340,7 @@ void LocationLink::validate( const Data& data )
     Json::validatePropertyIs< Range >( context, data, Identifier::targetRange, true );
     Json::validatePropertyIs< Range >( context, data, Identifier::originSelectionRange, false );
     Json::validatePropertyIs< Range >( context, data, Identifier::targetSelectionRange, false );
-} 
+}
 
 //
 //
@@ -6794,7 +6794,7 @@ void DocumentColorParams::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-} 
+}
 
 //
 // Color
@@ -6843,7 +6843,7 @@ void Color::validate( const Data& data )
     Json::validatePropertyIsNumber( context, data, Identifier::green, true );
     Json::validatePropertyIsNumber( context, data, Identifier::blue, true );
     Json::validatePropertyIsNumber( context, data, Identifier::alpha, true );
-} 
+}
 
 //
 //
@@ -7133,7 +7133,7 @@ void FormattingOptions::validate( const Data& data )
     Json::validatePropertyIsNumber( context, data, Identifier::tabSize, true );
     Json::validatePropertyIsBoolean( context, data, Identifier::insertSpaces, true );
     validateAdditionalOptions( data );
-} 
+}
 
 //
 //
@@ -7195,7 +7195,7 @@ void DocumentRangeFormattingParams::validate( const Data& data )
     static const auto context = CONTENT + " DocumentRangeFormattingParams:";
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
-} 
+}
 
 //
 //
@@ -7631,4 +7631,3 @@ void FoldingRangeResult::validate( const Data& data )
 //  End:
 //  vim:noexpandtab:sw=4:ts=4:
 //
-

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -714,7 +714,7 @@ u1 CreateFileOptions::hasOverwrite( void ) const
 
 u1 CreateFileOptions::overwrite( void ) const
 {
-    return at( Identifier::overwrite );
+    return at( Identifier::overwrite ).get< u1 >();
 }
 
 void CreateFileOptions::setOverwrite( const u1 overwrite )
@@ -728,7 +728,7 @@ u1 CreateFileOptions::hasIgnoreIfExists( void ) const
 
 u1 CreateFileOptions::ignoreIfExists( void ) const
 {
-    return at( Identifier::ignoreIfExists );
+    return at( Identifier::ignoreIfExists ).get< u1 >();
 }
 
 void CreateFileOptions::setIgnoreIfExists( const u1 ignoreIfExists )

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -6143,9 +6143,13 @@ DocumentLinkResult::DocumentLinkResult( const Data& data )
     validate( data );
 }
 
-DocumentLinkResult::DocumentLinkResult( const DocumentLink link )
-: Data( link )
+DocumentLinkResult::DocumentLinkResult( const DocumentLinks links )
+: Data( Data::array() )
 {
+    for( auto link : links )
+    {
+        push_back( link );
+    }
 }
 
 void DocumentLinkResult::validate( const Data& data )
@@ -6157,7 +6161,7 @@ void DocumentLinkResult::validate( const Data& data )
     }
     else
     {
-        DocumentLink::validate( data );
+        Content::validateTypeIsArrayOf< DocumentLink >( data, context );
     }
 }
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -3125,6 +3125,27 @@ void ConfigurationItem::validate( const Data& data )
 
 //
 //
+// ConfigurationResult
+//
+ConfigurationResult::ConfigurationResult( void )
+: Data( Data::array() )
+{
+}
+
+ConfigurationResult::ConfigurationResult( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+void ConfigurationResult::validate( const Data& data )
+{
+    static const auto context = CONTENT + " ConfigurationResult:";
+    Content::validateTypeIsArray( context, data );
+}
+
+//
+//
 // ConfigurationParams
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2802,6 +2802,21 @@ void ServerCapabilities::setExperimental( const Data& experimental )
     operator[]( Identifier::experimental ) = Data::from_cbor( Data::to_cbor( experimental ) );
 }
 
+u1 ServerCapabilities::hasWorkspace( void ) const
+{
+    return find( Identifier::workspace ) != end();
+}
+
+void ServerCapabilities::setWorkspace( const Workspace& workspace )
+{
+    operator[]( Identifier::workspace ) = Data::from_cbor( Data::to_cbor( workspace ) );
+}
+
+Workspace ServerCapabilities::workspace( void ) const
+{
+    return at( Identifier::workspace );
+}
+
 void ServerCapabilities::validate( const Data& data )
 {
     static const auto context = CONTENT + " SignatureHelpOptions:";
@@ -2834,6 +2849,14 @@ void ServerCapabilities::validate( const Data& data )
     Content::validatePropertyIs< ExecuteCommandOptions >(
         context, data, Identifier::executeCommandProvider, false );
     Content::validatePropertyIsObject( context, data, Identifier::experimental, false );
+    Content::validatePropertyIs< Workspace >( context, data, Identifier::workspace, false );
+    Content::validatePropertyIs< ColorProvider >( context, data, Identifier::colorProvider, false );
+    Content::validatePropertyIs< FoldingRangeProvider >(
+        context, data, Identifier::foldingRangeProvider, false );
+    Content::validatePropertyIs< ImplementationProvider >(
+        context, data, Identifier::implementationProvider, false );
+    Content::validatePropertyIs< TypeDefinitionProvider >(
+        context, data, Identifier::typeDefinitionProvider, false );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -793,6 +793,63 @@ void CreateFile::validate( const Data& data )
     Content::validatePropertyIsString( context, data, Identifier::uri, true );
     Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
 }
+//
+//
+// RenameFile
+//
+
+RenameFile::RenameFile( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+RenameFile::RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri )
+{
+    operator[]( Identifier::kind ) = std::string( Identifier::rename );
+    operator[]( Identifier::oldUri ) = oldUri.toString();
+    operator[]( Identifier::newUri ) = newUri.toString();
+}
+
+DocumentUri RenameFile::oldUri( void ) const
+{
+    return DocumentUri::fromString( operator[]( Identifier::oldUri ).get< std::string >() );
+}
+
+DocumentUri RenameFile::newUri( void ) const
+{
+    return DocumentUri::fromString( operator[]( Identifier::newUri ).get< std::string >() );
+}
+
+std::string RenameFile::kind( void ) const
+{
+    return operator[]( Identifier::kind ).get< std::string >();
+}
+
+u1 RenameFile::hasOptions( void ) const
+{
+    return find( Identifier::options ) != end();
+}
+
+void RenameFile::setOptions( const RenameFileOptions& options )
+{
+    operator[]( Identifier::options ) = Data::from_cbor( Data::to_cbor( options ) );
+}
+
+RenameFileOptions RenameFile::options( void ) const
+{
+    return at( Identifier::options );
+}
+
+void RenameFile::validate( const Data& data )
+{
+    static const auto context = CONTENT + " RenameFile:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsString( context, data, Identifier::kind, true );
+    Content::validatePropertyIsString( context, data, Identifier::newUri, true );
+    Content::validatePropertyIsString( context, data, Identifier::oldUri, true );
+    Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
+}
 
 //
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -4289,6 +4289,49 @@ void CompletionList::validate( const Data& data )
 }
 //
 //
+// CompletionResult
+//
+CompletionResult::CompletionResult( void )
+: Data( Data() )
+{
+}
+
+CompletionResult::CompletionResult( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+CompletionResult::CompletionResult( const CompletionList& list )
+: Data( Data::from_cbor( Data::to_cbor( list ) ) )
+{
+}
+
+CompletionResult::CompletionResult( const CompletionItems& items )
+: Data( Data::object() )
+{
+    operator[]( Identifier::isIncomplete ) = false;
+    operator[]( Identifier::items ) = Data::array();
+    for( auto item : items )
+    {
+        operator[]( Identifier::items ).push_back( item );
+    }
+}
+
+void CompletionResult::validate( const Data& data )
+{
+    if( data.is_null() )
+    {
+        // ok, do nothing.
+    }
+    else
+    {
+        CompletionList::validate( data );
+    }
+}
+
+//
+//
 // CompletionRegistrationOptions
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -850,6 +850,54 @@ void RenameFile::validate( const Data& data )
     Content::validatePropertyIsString( context, data, Identifier::oldUri, true );
     Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
 }
+//
+//
+// DeleteFileOptions
+//
+
+DeleteFileOptions::DeleteFileOptions( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 DeleteFileOptions::hasRecursive( void ) const
+{
+    return find( Identifier::recursive ) != end();
+}
+
+u1 DeleteFileOptions::recursive( void ) const
+{
+    return at( Identifier::recursive ).get< u1 >();
+}
+
+void DeleteFileOptions::setRecursive( const u1 recursive )
+{
+    operator[]( Identifier::recursive ) = recursive;
+}
+
+u1 DeleteFileOptions::hasIgnoreIfExists( void ) const
+{
+    return find( Identifier::ignoreIfExists ) != end();
+}
+
+u1 DeleteFileOptions::ignoreIfExists( void ) const
+{
+    return at( Identifier::ignoreIfExists );
+}
+
+void DeleteFileOptions::setIgnoreIfExists( const u1 ignoreIfExists )
+{
+    operator[]( Identifier::ignoreIfExists ) = ignoreIfExists;
+}
+
+void DeleteFileOptions::validate( const Data& data )
+{
+    static const auto context = CONTENT + " DeleteFileOptions:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
+    Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
+}
 
 //
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -691,6 +691,60 @@ void WorkspaceEdit::validate( const Data& data )
 
 //
 //
+// CreateFileOptions
+//
+
+CreateFileOptions::CreateFileOptions( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+CreateFileOptions::CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists )
+: Data( Data::object() )
+{
+    operator[]( Identifier::overwrite ) = overwrite;
+    operator[]( Identifier::ignoreIfExists ) = ignoreIfExists;
+}
+
+u1 CreateFileOptions::hasOverwrite( void ) const
+{
+    return find( Identifier::overwrite ) != end();
+}
+
+u1 CreateFileOptions::overwrite( void ) const
+{
+    return at( Identifier::overwrite );
+}
+
+void CreateFileOptions::setOverwrite( const u1 overwrite )
+{
+    operator[]( Identifier::overwrite ) = overwrite;
+}
+u1 CreateFileOptions::hasIgnoreIfExists( void ) const
+{
+    return find( Identifier::ignoreIfExists ) != end();
+}
+
+u1 CreateFileOptions::ignoreIfExists( void ) const
+{
+    return at( Identifier::ignoreIfExists );
+}
+
+void CreateFileOptions::setIgnoreIfExists( const u1 ignoreIfExists )
+{
+    operator[]( Identifier::ignoreIfExists ) = ignoreIfExists;
+}
+void CreateFileOptions::validate( const Data& data )
+{
+    static const auto context = CONTENT + " CreateFileOptions:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
+    Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
+}
+
+//
+//
 // TextDocumentItem
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2186,6 +2186,38 @@ void DocumentOnTypeFormattingOptions::validate( const Data& data )
 
 //
 //
+// RenameOptions
+//
+RenameOptions::RenameOptions( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 RenameOptions::hasPrepareProvider( void ) const
+{
+    return find( Identifier::prepareProvider ) != end();
+}
+
+u1 RenameOptions::prepareProvider( void ) const
+{
+    return at( Identifier::prepareProvider );
+}
+
+void RenameOptions::setPrepareProvider( const u1 prepareProvider )
+{
+    operator[]( Identifier::prepareProvider ) = prepareProvider;
+}
+
+void RenameOptions::validate( const Data& data )
+{
+    static const auto context = CONTENT + " RenameOptions:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsBoolean( context, data, Identifier::prepareProvider, false );
+}
+
+//
+//
 // ExecuteCommandOptions
 //
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2365,6 +2365,40 @@ void ServerCapabilities::setDefinitionProvider( const u1 definitionProvider )
     operator[]( Identifier::definitionProvider ) = definitionProvider;
 }
 
+u1 ServerCapabilities::hasTypeDefinitionProvider( void ) const
+{
+    return find( Identifier::typeDefinitionProvider ) != end();
+}
+
+TypeDefinitionProvider ServerCapabilities::typeDefinitionProvider( void ) const
+{
+    return at( Identifier::typeDefinitionProvider );
+}
+
+void ServerCapabilities::setTypeDefinitionProvider(
+    const TypeDefinitionProvider& typeDefinitionProvider )
+{
+    operator[]( Identifier::typeDefinitionProvider ) =
+        Data::from_cbor( Data::to_cbor( typeDefinitionProvider ) );
+}
+
+u1 ServerCapabilities::hasImplementationProvider( void ) const
+{
+    return find( Identifier::implementationProvider ) != end();
+}
+
+ImplementationProvider ServerCapabilities::implementationProvider( void ) const
+{
+    return at( Identifier::implementationProvider );
+}
+
+void ServerCapabilities::setImplementationProvider(
+    const ImplementationProvider& implementationProvider )
+{
+    operator[]( Identifier::implementationProvider ) =
+        Data::from_cbor( Data::to_cbor( implementationProvider ) );
+}
+
 u1 ServerCapabilities::hasReferencesProvider( void ) const
 {
     return find( Identifier::referencesProvider ) != end();

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2532,7 +2532,7 @@ ShowMessageRequestResult::ShowMessageRequestResult( const Data& data )
 }
 
 ShowMessageRequestResult::ShowMessageRequestResult( const MessageActionItem& item )
-: Data( item )
+: Data( Data::from_cbor( Data::to_cbor( item ) ) )
 {
 }
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -3470,27 +3470,24 @@ WorkspaceSymbolResult::WorkspaceSymbolResult( const Data& data )
 }
 
 WorkspaceSymbolResult::WorkspaceSymbolResult( const SymbolInformations& symbolInformation )
-: Data( Data::object() )
+: Data( Data::array() )
 {
-    operator[]( Identifier::symbolInformation ) = Data::array();
-
     for( auto information : symbolInformation )
     {
-        operator[]( Identifier::symbolInformation ).push_back( information );
+        push_back( information );
     }
 }
 
 void WorkspaceSymbolResult::addSymbolInformation( const SymbolInformation& information )
 {
-    operator[]( Identifier::symbolInformation ).push_back( information );
+    push_back( information );
 }
 
 SymbolInformations WorkspaceSymbolResult::symbolInformation( void ) const
 {
-    auto infos = operator[]( Identifier::symbolInformation );
     auto result = SymbolInformations();
 
-    for( auto info : infos )
+    for( auto info : *this )
     {
         result.emplace_back( info );
     }
@@ -3501,8 +3498,14 @@ void WorkspaceSymbolResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " workspaceSymbolResult:";
     Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< SymbolInformation >(
-        context, data, Identifier::symbolInformation, true );
+    if( data.is_null() )
+    {
+        // ok, do nothing
+    }
+    else
+    {
+        Content::validateTypeIsArrayOf< SymbolInformation >( context, data );
+    }
 }
 //
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -1284,6 +1284,35 @@ void WorkspaceClientCapabilities::executeCommand( const DynamicRegistration& exe
 {
     operator[]( Identifier::executeCommand ) = Data::from_cbor( Data::to_cbor( executeCommand ) );
 }
+u1 WorkspaceClientCapabilities::hasWorkspaceFolders( void ) const
+{
+    return find( Identifier::workspaceFolders ) != end();
+}
+
+void WorkspaceClientCapabilities::setWorkspaceFolders( const u1 workspaceFolders )
+{
+    operator[]( Identifier::workspaceFolders ) = workspaceFolders;
+}
+
+u1 WorkspaceClientCapabilities::workspaceFolders( void ) const
+{
+    return at( Identifier::workspaceFolders ).get< u1 >();
+}
+
+u1 WorkspaceClientCapabilities::hasConfiguration( void ) const
+{
+    return find( Identifier::configuration ) != end();
+}
+
+void WorkspaceClientCapabilities::setConfiguration( const u1 configuration )
+{
+    operator[]( Identifier::configuration ) = configuration;
+}
+
+u1 WorkspaceClientCapabilities::configuration( void ) const
+{
+    return at( Identifier::configuration ).get< u1 >();
+}
 
 void WorkspaceClientCapabilities::validate( const Data& data )
 {
@@ -1299,6 +1328,8 @@ void WorkspaceClientCapabilities::validate( const Data& data )
     Content::validatePropertyIs< DynamicRegistration >( context, data, Identifier::symbol, false );
     Content::validatePropertyIs< DynamicRegistration >(
         context, data, Identifier::executeCommand, false );
+    Content::validatePropertyIsBoolean( context, data, Identifier::configuration, false );
+    Content::validatePropertyIsBoolean( context, data, Identifier::workspaceFolders, false );
 }
 
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -805,6 +805,7 @@ RenameFile::RenameFile( const Data& data )
 }
 
 RenameFile::RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri )
+: Data( Data::object() )
 {
     operator[]( Identifier::kind ) = std::string( Identifier::rename );
     operator[]( Identifier::oldUri ) = oldUri.toString();
@@ -897,6 +898,55 @@ void DeleteFileOptions::validate( const Data& data )
     Content::validateTypeIsObject( context, data );
     Content::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
     Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
+}
+//
+//
+//  DeleteFile
+//
+DeleteFile::DeleteFile( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+DeleteFile::DeleteFile( const DocumentUri& uri )
+: Data( Data::object() )
+{
+    operator[]( Identifier::kind ) = Identifier::DELETE;
+    operator[]( Identifier::uri ) = uri.toString();
+}
+
+DocumentUri DeleteFile::uri( void ) const
+{
+    return DocumentUri::fromString( operator[]( Identifier::uri ).get< std::string >() );
+}
+
+std::string DeleteFile::kind( void ) const
+{
+    return operator[]( Identifier::kind ).get< std::string >();
+}
+
+u1 DeleteFile::hasOptions( void ) const
+{
+    return find( Identifier::options ) != end();
+}
+
+void DeleteFile::setOptions( const DeleteFileOptions& options )
+{
+    operator[]( Identifier::options ) = Data::from_cbor( Data::to_cbor( options ) );
+}
+
+DeleteFileOptions DeleteFile::options( void ) const
+{
+    return at( Identifier::options );
+}
+void DeleteFile::validate( const Data& data )
+{
+    static const auto context = CONTENT + " DeleteFile:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsString( context, data, Identifier::kind, true );
+    Content::validatePropertyIsString( context, data, Identifier::uri, true );
+    Content::validatePropertyIs< DeleteFileOptions >( context, data, Identifier::options, false );
 }
 
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2594,6 +2594,30 @@ void InitializeParams::setTrace( const std::string& trace )
     operator[]( Identifier::trace ) = trace;
 }
 
+WorkspaceFolders InitializeParams::workspaceFolders( void ) const
+{
+    auto folders = WorkspaceFolders();
+    for( auto folder : at( Identifier::workspaceFolders ) )
+    {
+        folders.push_back( folder );
+    }
+    return folders;
+}
+
+u1 InitializeParams::hasWorkspaceFolders( void ) const
+{
+    return find( Identifier::workspaceFolders ) != end();
+}
+
+void InitializeParams::addWorkspaceFolder( WorkspaceFolder folder )
+{
+    if( not hasWorkspaceFolders() )
+    {
+        operator[]( Identifier::workspaceFolders ) = Data::array();
+    }
+    operator[]( Identifier::workspace_workspaceFolders ).push_back( folder );
+}
+
 void InitializeParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " InitializeParams:";
@@ -2605,6 +2629,16 @@ void InitializeParams::validate( const Data& data )
     Content::validatePropertyIsNumberOrNull( context, data, Identifier::processId, false );
     Content::validatePropertyIsObject( context, data, Identifier::initializationOptions, false );
     Content::validatePropertyIsString( context, data, Identifier::trace, false );
+    if( Content::hasProperty( data, Identifier::workspaceFolders ) &&
+        data[ Identifier::workspaceFolders ].is_null() )
+    {
+        // ok, do nothing
+    }
+    else
+    {
+        Content::validatePropertyIsArrayOf< WorkspaceFolder >(
+            context, data, Identifier::workspaceFolders, false );
+    }
 }
 
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -181,9 +181,9 @@ Position Range::end( void ) const
 void Range::validate( const Data& data )
 {
     static const auto context = CONTENT + " Range:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Position >( context, data, Identifier::start, true );
-    Content::validatePropertyIs< Position >( context, data, Identifier::end, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Position >( context, data, Identifier::start, true );
+    Json::validatePropertyIs< Position >( context, data, Identifier::end, true );
 }
 
 //
@@ -252,9 +252,9 @@ std::string DiagnosticRelatedInformation::message( void ) const
 void DiagnosticRelatedInformation::validate( const Data& data )
 {
     static const auto context = CONTENT + " DiagnosticRelatedInformation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Location >( context, data, Identifier::location, true );
-    Content::validatePropertyIsString( context, data, Identifier::message, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Location >( context, data, Identifier::location, true );
+    Json::validatePropertyIsString( context, data, Identifier::message, true );
 }
 //
 //
@@ -625,9 +625,9 @@ void CreateFileOptions::setIgnoreIfExists( const u1 ignoreIfExists )
 void CreateFileOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " CreateFileOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
 }
 //
 //
@@ -675,10 +675,10 @@ CreateFileOptions CreateFile::options( void ) const
 void CreateFile::validate( const Data& data )
 {
     static const auto context = CONTENT + " CreateFile:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::kind, true );
-    Content::validatePropertyIsString( context, data, Identifier::uri, true );
-    Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::kind, true );
+    Json::validatePropertyIsString( context, data, Identifier::uri, true );
+    Json::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
 }
 //
 //
@@ -732,11 +732,11 @@ RenameFileOptions RenameFile::options( void ) const
 void RenameFile::validate( const Data& data )
 {
     static const auto context = CONTENT + " RenameFile:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::kind, true );
-    Content::validatePropertyIsString( context, data, Identifier::newUri, true );
-    Content::validatePropertyIsString( context, data, Identifier::oldUri, true );
-    Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::kind, true );
+    Json::validatePropertyIsString( context, data, Identifier::newUri, true );
+    Json::validatePropertyIsString( context, data, Identifier::oldUri, true );
+    Json::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
 }
 //
 //
@@ -782,9 +782,9 @@ void DeleteFileOptions::setIgnoreIfExists( const u1 ignoreIfExists )
 void DeleteFileOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " DeleteFileOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
 }
 //
 //
@@ -830,10 +830,10 @@ DeleteFileOptions DeleteFile::options( void ) const
 void DeleteFile::validate( const Data& data )
 {
     static const auto context = CONTENT + " DeleteFile:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::kind, true );
-    Content::validatePropertyIsString( context, data, Identifier::uri, true );
-    Content::validatePropertyIs< DeleteFileOptions >( context, data, Identifier::options, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::kind, true );
+    Json::validatePropertyIsString( context, data, Identifier::uri, true );
+    Json::validatePropertyIs< DeleteFileOptions >( context, data, Identifier::options, false );
 }
 
 //
@@ -1215,8 +1215,8 @@ void WorkspaceClientCapabilities::validate( const Data& data )
     Json::validatePropertyIs< DynamicRegistration >( context, data, Identifier::symbol, false );
     Json::validatePropertyIs< DynamicRegistration >(
         context, data, Identifier::executeCommand, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::configuration, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::workspaceFolders, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::configuration, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::workspaceFolders, false );
 }
 
 //
@@ -1395,9 +1395,9 @@ void TextDocumentClientCapabilities::Completion::completionItem(
 void TextDocumentClientCapabilities::Completion::validate( const Data& data )
 {
     static const auto context = CONTENT + " Completion:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::dynamicRegistration, false );
-    Content::validatePropertyIs< TextDocumentClientCapabilities::CompletionItem >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::dynamicRegistration, false );
+    Json::validatePropertyIs< TextDocumentClientCapabilities::CompletionItem >(
         context, data, Identifier::completionItem, false );
 }
 
@@ -2094,8 +2094,8 @@ void RenameOptions::setPrepareProvider( const u1 prepareProvider )
 void RenameOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " RenameOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::prepareProvider, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::prepareProvider, false );
 }
 
 //
@@ -2165,8 +2165,8 @@ void StaticRegistrationOptions::setId( std::string id )
 void StaticRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " StaticRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::id, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::id, false );
 }
 
 //
@@ -2226,7 +2226,7 @@ ColorProviderOptions::ColorProviderOptions( const Data& data )
 void ColorProviderOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorProviderOptions:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
 }
 
 //
@@ -2295,8 +2295,8 @@ Workspace::Workspace( const Data& data )
 void Workspace::validate( const Data& data )
 {
     static const auto context = CONTENT + " Workspace:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Workspace::WorkspaceFolders >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Workspace::WorkspaceFolders >(
         context, data, Identifier::workspaceFolders, false );
 }
 
@@ -2371,15 +2371,15 @@ std::string Workspace::WorkspaceFolders::changeNotifications( void ) const
 void Workspace::WorkspaceFolders::validate( const Data& data )
 {
     static const auto context = CONTENT + " Workspace::WorkspaceFolders:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::supported, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::supported, false );
     try
     {
-        Content::validatePropertyIsString( context, data, Identifier::changeNotifications, false );
+        Json::validatePropertyIsString( context, data, Identifier::changeNotifications, false );
     }
     catch( std::invalid_argument a )
     {
-        Content::validatePropertyIsBoolean( context, data, Identifier::changeNotifications, false );
+        Json::validatePropertyIsBoolean( context, data, Identifier::changeNotifications, false );
     }
 }
 
@@ -2791,14 +2791,14 @@ void ServerCapabilities::validate( const Data& data )
         context, data, Identifier::documentLinkProvider, false );
     Json::validatePropertyIs< ExecuteCommandOptions >(
         context, data, Identifier::executeCommandProvider, false );
-    Content::validatePropertyIsObject( context, data, Identifier::experimental, false );
-    Content::validatePropertyIs< Workspace >( context, data, Identifier::workspace, false );
-    Content::validatePropertyIs< ColorProvider >( context, data, Identifier::colorProvider, false );
-    Content::validatePropertyIs< FoldingRangeProvider >(
+    Json::validatePropertyIsObject( context, data, Identifier::experimental, false );
+    Json::validatePropertyIs< Workspace >( context, data, Identifier::workspace, false );
+    Json::validatePropertyIs< ColorProvider >( context, data, Identifier::colorProvider, false );
+    Json::validatePropertyIs< FoldingRangeProvider >(
         context, data, Identifier::foldingRangeProvider, false );
-    Content::validatePropertyIs< ImplementationProvider >(
+    Json::validatePropertyIs< ImplementationProvider >(
         context, data, Identifier::implementationProvider, false );
-    Content::validatePropertyIs< TypeDefinitionProvider >(
+    Json::validatePropertyIs< TypeDefinitionProvider >(
         context, data, Identifier::typeDefinitionProvider, false );
 }
 
@@ -2902,17 +2902,17 @@ void InitializeParams::validate( const Data& data )
     Json::validatePropertyIsUriOrNull( context, data, Identifier::rootUri, true );
     Json::validatePropertyIs< ClientCapabilities >( context, data, Identifier::capabilities, true );
 
-    Content::validatePropertyIsNumberOrNull( context, data, Identifier::processId, false );
-    Content::validatePropertyIsObject( context, data, Identifier::initializationOptions, false );
-    Content::validatePropertyIsString( context, data, Identifier::trace, false );
-    if( Content::hasProperty( data, Identifier::workspaceFolders ) &&
+    Json::validatePropertyIsNumberOrNull( context, data, Identifier::processId, false );
+    Json::validatePropertyIsObject( context, data, Identifier::initializationOptions, false );
+    Json::validatePropertyIsString( context, data, Identifier::trace, false );
+    if( Json::hasProperty( data, Identifier::workspaceFolders ) &&
         data[ Identifier::workspaceFolders ].is_null() )
     {
         // ok, do nothing
     }
     else
     {
-        Content::validatePropertyIsArrayOf< WorkspaceFolder >(
+        Json::validatePropertyIsArrayOf< WorkspaceFolder >(
             context, data, Identifier::workspaceFolders, false );
     }
 }
@@ -3010,14 +3010,14 @@ std::string CancelParams::id( void ) const
 void CancelParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " CancelParams:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data[ Identifier::id ].is_number() )
     {
-        Content::validatePropertyIsNumber( context, data, Identifier::id, true );
+        Json::validatePropertyIsNumber( context, data, Identifier::id, true );
     }
     else
     {
-        Content::validatePropertyIsString( context, data, Identifier::id, true );
+        Json::validatePropertyIsString( context, data, Identifier::id, true );
     }
 }
 
@@ -3052,9 +3052,9 @@ std::string ShowMessageParams::message( void ) const
 void ShowMessageParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ShowMessageParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::message, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::type, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::message, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::type, true );
 }
 
 //
@@ -3082,8 +3082,8 @@ std::string MessageActionItem::title( void ) const
 void MessageActionItem::validate( const Data& data )
 {
     static const auto context = CONTENT + " MessageActionItem:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::title, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::title, true );
 }
 
 //
@@ -3182,9 +3182,9 @@ std::string ShowMessageRequestParams::message( void ) const
 void ShowMessageRequestParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ShowMessageRequestParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::title, true );
-    Content::validatePropertyIsArray( context, data, Identifier::actions, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::title, true );
+    Json::validatePropertyIsArray( context, data, Identifier::actions, false );
 }
 
 TelemetryEventParams::TelemetryEventParams( const Data& data )
@@ -3196,7 +3196,7 @@ TelemetryEventParams::TelemetryEventParams( const Data& data )
 void TelemetryEventParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " TelemetryEventParams:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
 }
 
 //
@@ -3249,10 +3249,10 @@ void Registration::addRegisterOption( const Data& option )
 void Registration::validate( const Data& data )
 {
     static const auto context = CONTENT + " Registration:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::id, true );
-    Content::validatePropertyIsString( context, data, Identifier::method, true );
-    Content::validatePropertyIsArray( context, data, Identifier::registerOptions, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::id, true );
+    Json::validatePropertyIsString( context, data, Identifier::method, true );
+    Json::validatePropertyIsArray( context, data, Identifier::registerOptions, false );
 }
 
 //
@@ -3289,8 +3289,8 @@ Registrations RegistrationParams::registrations( void ) const
 void RegistrationParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " RegistrationParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArray( context, data, Identifier::registrations, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArray( context, data, Identifier::registrations, true );
 }
 
 //
@@ -3319,7 +3319,7 @@ DocumentSelector TextDocumentRegistrationOptions::documentSelector( void ) const
 void TextDocumentRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " TextDocumentRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data.find( Identifier::documentSelector ) != data.end() and
         data[ Identifier::documentSelector ].is_null() )
     {
@@ -3327,7 +3327,7 @@ void TextDocumentRegistrationOptions::validate( const Data& data )
     }
     else
     {
-        Content::validatePropertyIs< DocumentSelector >(
+        Json::validatePropertyIs< DocumentSelector >(
             context, data, Identifier::documentSelector, true );
     }
 }
@@ -3359,8 +3359,8 @@ TextDocumentSyncKind TextDocumentChangeRegistrationOptions::kind( void ) const
 void TextDocumentChangeRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " TextDocumentChangeRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, true );
 }
 
 //
@@ -3394,9 +3394,9 @@ std::string Unregistration::method( void ) const
 void Unregistration::validate( const Data& data )
 {
     static const auto context = CONTENT + " Unregistration:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::id, true );
-    Content::validatePropertyIsString( context, data, Identifier::method, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::id, true );
+    Json::validatePropertyIsString( context, data, Identifier::method, true );
 }
 
 //
@@ -3434,8 +3434,8 @@ Unregistrations UnregistrationParams::unregistrations( void ) const
 void UnregistrationParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " UnregistrationParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArray( context, data, Identifier::unregistrations, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArray( context, data, Identifier::unregistrations, true );
 }
 
 //
@@ -3469,9 +3469,9 @@ std::string WorkspaceFolder::name( void ) const
 void WorkspaceFolder::validate( const Data& data )
 {
     static const auto context = CONTENT + " WorkspaceFolder:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::uri, true );
-    Content::validatePropertyIsString( context, data, Identifier::name, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::uri, true );
+    Json::validatePropertyIsString( context, data, Identifier::name, true );
 }
 
 //
@@ -3520,7 +3520,7 @@ void WorkspaceFoldersResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< WorkspaceFolder >( context, data );
+        Json::validateTypeIsArrayOf< WorkspaceFolder >( context, data );
     }
 }
 
@@ -3579,11 +3579,10 @@ WorkspaceFolders WorkspaceFoldersChangeEvent::removed( void ) const
 void WorkspaceFoldersChangeEvent::validate( const Data& data )
 {
     static const auto context = CONTENT + " WorkspaceFoldersChangeEvent:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
 
-    Content::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::added, true );
-    Content::validatePropertyIsArrayOf< WorkspaceFolder >(
-        context, data, Identifier::removed, true );
+    Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::added, true );
+    Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::removed, true );
 }
 //
 //
@@ -3610,8 +3609,8 @@ WorkspaceFoldersChangeEvent DidChangeWorkspaceFoldersParams::event( void ) const
 void DidChangeWorkspaceFoldersParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidChangeWorkspaceFoldersParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< WorkspaceFoldersChangeEvent >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< WorkspaceFoldersChangeEvent >(
         context, data, Identifier::event, true );
 }
 
@@ -3636,7 +3635,7 @@ DidChangeConfigurationSettings DidChangeConfigurationParams::settings( void ) co
 void DidChangeConfigurationParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidChangeConfigurationParams:";
-    Content::validatePropertyIsObject( context, data, Identifier::settings, true );
+    Json::validatePropertyIsObject( context, data, Identifier::settings, true );
 }
 
 //
@@ -3690,9 +3689,9 @@ void ConfigurationItem::setScopeUri( const std::string& uri )
 void ConfigurationItem::validate( const Data& data )
 {
     static const auto context = CONTENT + " ConfigurationItem:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::section, false );
-    Content::validatePropertyIsString( context, data, Identifier::scopeUri, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::section, false );
+    Json::validatePropertyIsString( context, data, Identifier::scopeUri, false );
 }
 
 //
@@ -3713,7 +3712,7 @@ ConfigurationResult::ConfigurationResult( const Data& data )
 void ConfigurationResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " ConfigurationResult:";
-    Content::validateTypeIsArray( context, data );
+    Json::validateTypeIsArray( context, data );
 }
 
 //
@@ -3752,9 +3751,8 @@ ConfigurationItems ConfigurationParams::items( void ) const
 void ConfigurationParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ConfigurationParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< ConfigurationItem >(
-        context, data, Identifier::items, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOf< ConfigurationItem >( context, data, Identifier::items, true );
 }
 
 //
@@ -3788,9 +3786,9 @@ FileChangeType FileEvent::type( void ) const
 void FileEvent::validate( const Data& data )
 {
     static const auto context = CONTENT + " FileEvent:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsUri( context, data, Identifier::uri, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::type, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsUri( context, data, Identifier::uri, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::type, true );
 }
 
 //
@@ -3828,8 +3826,8 @@ FileEvents DidChangeWatchedFilesParams::changes( void ) const
 void DidChangeWatchedFilesParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidChangeWatchedFilesParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArray( context, data, Identifier::changes, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArray( context, data, Identifier::changes, true );
 }
 
 //
@@ -3878,9 +3876,9 @@ void FileSystemWatcher::setKind( const WatchKind kind )
 void FileSystemWatcher::validate( const Data& data )
 {
     static const auto context = CONTENT + " FileSystemWatchers:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::globPattern, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::globPattern, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, false );
 }
 
 //
@@ -3921,8 +3919,8 @@ FileSystemWatchers DidChangeWatchedFilesRegistrationOptions::watchers( void ) co
 void DidChangeWatchedFilesRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidChangeWatchedFilesRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< FileSystemWatcher >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOf< FileSystemWatcher >(
         context, data, Identifier::watchers, true );
 }
 
@@ -3951,8 +3949,8 @@ std::string WorkspaceSymbolParams::query( void ) const
 void WorkspaceSymbolParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " WorkspaceSymbolParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::query, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::query, true );
 }
 
 //
@@ -4022,12 +4020,12 @@ SymbolKind SymbolInformation::kind( void ) const
 void SymbolInformation::validate( const Data& data )
 {
     static const auto context = CONTENT + " SymbolInformation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::name, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, true );
-    Content::validatePropertyIs< Location >( context, data, Identifier::location, true );
-    Content::validatePropertyIsString( context, data, Identifier::containerName, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::name, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, true );
+    Json::validatePropertyIs< Location >( context, data, Identifier::location, true );
+    Json::validatePropertyIsString( context, data, Identifier::containerName, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
 }
 
 //
@@ -4068,14 +4066,14 @@ SymbolInformations WorkspaceSymbolResult::symbolInformation( void ) const
 void WorkspaceSymbolResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " workspaceSymbolResult:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data.is_null() )
     {
         // ok, do nothing
     }
     else
     {
-        Content::validateTypeIsArrayOf< SymbolInformation >( context, data );
+        Json::validateTypeIsArrayOf< SymbolInformation >( context, data );
     }
 }
 //
@@ -4118,9 +4116,9 @@ void ApplyWorkspaceEditParams::setLabel( const std::string& label )
 void ApplyWorkspaceEditParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ApplyWorkspaceEditParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< WorkspaceEdit >( context, data, Identifier::edit, true );
-    Content::validatePropertyIsString( context, data, Identifier::label, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< WorkspaceEdit >( context, data, Identifier::edit, true );
+    Json::validatePropertyIsString( context, data, Identifier::label, false );
 }
 
 //
@@ -4147,8 +4145,8 @@ u1 ApplyWorkspaceEditResult::applied( void ) const
 void ApplyWorkspaceEditResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " ApplyWorkspaceEditResult:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::applied, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::applied, true );
 }
 
 //
@@ -4176,9 +4174,8 @@ TextDocumentItem DidOpenTextDocumentParams::textDocument( void ) const
 void DidOpenTextDocumentParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidOpenTextDocumentParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentItem >(
-        context, data, Identifier::textDocument, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentItem >( context, data, Identifier::textDocument, false );
 }
 
 //
@@ -4236,10 +4233,10 @@ std::string TextDocumentContentChangeEvent::text( void ) const
 void TextDocumentContentChangeEvent::validate( const Data& data )
 {
     static const auto context = CONTENT + " TextDocumentContentChangeEvent:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::text, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, false );
-    Content::validatePropertyIsNumber( context, data, Identifier::rangeLength, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::text, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, false );
+    Json::validatePropertyIsNumber( context, data, Identifier::rangeLength, false );
 }
 
 //
@@ -4286,10 +4283,10 @@ TextDocumentContentChangeEvents DidChangeTextDocumentParams::contentChanges( voi
 void DidChangeTextDocumentParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidChangeTextDocumentParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< VersionedTextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< VersionedTextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIsArrayOf< TextDocumentContentChangeEvent >(
+    Json::validatePropertyIsArrayOf< TextDocumentContentChangeEvent >(
         context, data, Identifier::contentChanges, true );
 }
 
@@ -4326,10 +4323,10 @@ TextDocumentIdentifier WillSaveTextDocumentParams::textDocument( void ) const
 void WillSaveTextDocumentParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " WillSaveTextDocumentParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::reason, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::reason, true );
 }
 
 //
@@ -4367,14 +4364,14 @@ TextEdits WillSaveWaitUntilResponse::textEdit( void ) const
 void WillSaveWaitUntilResponse::validate( const Data& data )
 {
     static const auto context = CONTENT + " WillSaveWaitUntilResponse:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data.find( Identifier::edit ) != data.end() and data[ Identifier::edit ].is_null() )
     {
         // ok, due to the possibility that the property can be null
     }
     else
     {
-        Content::validatePropertyIsArrayOf< TextEdit >( context, data, Identifier::edit, true );
+        Json::validatePropertyIsArrayOf< TextEdit >( context, data, Identifier::edit, true );
     }
 }
 
@@ -4418,10 +4415,10 @@ std::string DidSaveTextDocumentParams::text( void ) const
 void DidSaveTextDocumentParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidSaveTextDocumentParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIsString( context, data, Identifier::text, false );
+    Json::validatePropertyIsString( context, data, Identifier::text, false );
 }
 
 //
@@ -4449,8 +4446,8 @@ TextDocumentIdentifier DidCloseTextDocumentParams::textDocument( void ) const
 void DidCloseTextDocumentParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DidCloseTextDocumentParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 
@@ -4495,9 +4492,9 @@ CompletionTriggerKind CompletionContext::triggerKind( void ) const
 void CompletionContext::validate( const Data& data )
 {
     static const auto context = CONTENT + " CompletionContext:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsNumber( context, data, Identifier::triggerKind, true );
-    Content::validatePropertyIsString( context, data, Identifier::triggerCharacter, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsNumber( context, data, Identifier::triggerKind, true );
+    Json::validatePropertyIsString( context, data, Identifier::triggerCharacter, false );
 }
 
 //
@@ -4535,8 +4532,8 @@ void CompletionParams::setContext( const CompletionContext& context )
 void CompletionParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " CompletionParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< CompletionContext >( context, data, Identifier::context, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< CompletionContext >( context, data, Identifier::context, false );
 }
 
 //
@@ -4799,23 +4796,23 @@ Data CompletionItem::data( void ) const
 void CompletionItem::validate( const Data& data )
 {
     static const auto context = CONTENT + " CompletionItem:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::label, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, false );
-    Content::validatePropertyIsString( context, data, Identifier::detail, false );
-    Content::validatePropertyIs< MarkupContent >( context, data, Identifier::documentation, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::preselect, false );
-    Content::validatePropertyIsString( context, data, Identifier::sortText, false );
-    Content::validatePropertyIsString( context, data, Identifier::filterText, false );
-    Content::validatePropertyIsString( context, data, Identifier::insertText, false );
-    Content::validatePropertyIsNumber( context, data, Identifier::insertTextFormat, false );
-    Content::validatePropertyIs< TextEdit >( context, data, Identifier::textEdit, false );
-    Content::validatePropertyIsArrayOf< TextEdit >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::label, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, false );
+    Json::validatePropertyIsString( context, data, Identifier::detail, false );
+    Json::validatePropertyIs< MarkupContent >( context, data, Identifier::documentation, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::preselect, false );
+    Json::validatePropertyIsString( context, data, Identifier::sortText, false );
+    Json::validatePropertyIsString( context, data, Identifier::filterText, false );
+    Json::validatePropertyIsString( context, data, Identifier::insertText, false );
+    Json::validatePropertyIsNumber( context, data, Identifier::insertTextFormat, false );
+    Json::validatePropertyIs< TextEdit >( context, data, Identifier::textEdit, false );
+    Json::validatePropertyIsArrayOf< TextEdit >(
         context, data, Identifier::additionalTextEdits, false );
-    Content::validatePropertyIsArrayOfString( context, data, Identifier::commitCharacters, false );
-    Content::validatePropertyIs< Command >( context, data, Identifier::command, false );
-    Content::validatePropertyIsObject( context, data, Identifier::data, false );
+    Json::validatePropertyIsArrayOfString( context, data, Identifier::commitCharacters, false );
+    Json::validatePropertyIs< Command >( context, data, Identifier::command, false );
+    Json::validatePropertyIsObject( context, data, Identifier::data, false );
 }
 
 //
@@ -4858,9 +4855,9 @@ u1 CompletionList::isIncomplete( void ) const
 void CompletionList::validate( const Data& data )
 {
     static const auto context = CONTENT + " CompletionList:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< CompletionItem >( context, data, Identifier::items, true );
-    Content::validatePropertyIsBoolean( context, data, Identifier::isIncomplete, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOf< CompletionItem >( context, data, Identifier::items, true );
+    Json::validatePropertyIsBoolean( context, data, Identifier::isIncomplete, true );
 }
 //
 //
@@ -4966,9 +4963,9 @@ void CompletionRegistrationOptions::setResolveProvider( const u1 resolveProvider
 void CompletionRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " CompletionRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOfString( context, data, Identifier::triggerCharacters, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::resolveProvider, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOfString( context, data, Identifier::triggerCharacters, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::resolveProvider, false );
 }
 
 //
@@ -5021,13 +5018,13 @@ void MarkupContent::validate( const Data& data )
     static const auto context = CONTENT + " MarkupContent:";
     if( data.is_object() )
     {
-        Content::validateTypeIsObject( context, data );
-        Content::validatePropertyIsString( context, data, Identifier::value, true );
-        Content::validatePropertyIsString( context, data, Identifier::kind, true );
+        Json::validateTypeIsObject( context, data );
+        Json::validatePropertyIsString( context, data, Identifier::value, true );
+        Json::validatePropertyIsString( context, data, Identifier::kind, true );
     }
     else if( data.is_string() )
     {
-        Content::validateTypeIsString( context, data );
+        Json::validateTypeIsString( context, data );
     }
 }
 
@@ -5070,9 +5067,9 @@ void ParameterInformation::setDocumentation( const MarkupContent& doc )
 void ParameterInformation::validate( const Data& data )
 {
     static const auto context = CONTENT + " ParameterInformation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::label, true );
-    Content::validatePropertyIsString( context, data, Identifier::documentation, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::label, true );
+    Json::validatePropertyIsString( context, data, Identifier::documentation, false );
 }
 
 //
@@ -5140,10 +5137,10 @@ void SignatureInformation::setParameters( const ParameterInformations& parameter
 void SignatureInformation::validate( const Data& data )
 {
     static const auto context = CONTENT + " SignatureInformation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::label, true );
-    Content::validatePropertyIsString( context, data, Identifier::documentation, false );
-    Content::validatePropertyIsArrayOf< ParameterInformation >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::label, true );
+    Json::validatePropertyIsString( context, data, Identifier::documentation, false );
+    Json::validatePropertyIsArrayOf< ParameterInformation >(
         context, data, Identifier::parameters, false );
 }
 
@@ -5211,11 +5208,11 @@ std::size_t SignatureHelp::activeParameter( void ) const
 void SignatureHelp::validate( const Data& data )
 {
     static const auto context = CONTENT + " SignatureHelp:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< SignatureInformation >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOf< SignatureInformation >(
         context, data, Identifier::signatures, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::activeSignature, false );
-    Content::validatePropertyIsNumber( context, data, Identifier::activeParameter, false );
+    Json::validatePropertyIsNumber( context, data, Identifier::activeSignature, false );
+    Json::validatePropertyIsNumber( context, data, Identifier::activeParameter, false );
 }
 //
 //
@@ -5308,11 +5305,11 @@ Range LocationLink::targetSelectionRange( void ) const
 void LocationLink::validate( const Data& data )
 {
     static const auto context = CONTENT + " LocationLink:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::targetUri, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::targetRange, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::originSelectionRange, false );
-    Content::validatePropertyIs< Range >( context, data, Identifier::targetSelectionRange, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::targetUri, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::targetRange, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::originSelectionRange, false );
+    Json::validatePropertyIs< Range >( context, data, Identifier::targetSelectionRange, false );
 }
 //
 //
@@ -5350,8 +5347,8 @@ u1 TextDocumentSaveRegistrationOptions::includeText( void ) const
 void TextDocumentSaveRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " TextDocumentSaveRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::includeText, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::includeText, false );
 }
 
 //
@@ -5409,8 +5406,8 @@ TriggerCharacters SignatureHelpRegistrationOptions::triggerCharacters( void ) co
 void SignatureHelpRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " SignatureHelpRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOfString( context, data, Identifier::triggerCharacters, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOfString( context, data, Identifier::triggerCharacters, false );
 }
 
 //
@@ -5459,11 +5456,11 @@ void TypeDefinitionResult::validate( const Data& data )
     {
         if( data.is_array() )
         {
-            Content::validateTypeIsArrayOf< Location, LocationLink >( context, data );
+            Json::validateTypeIsArrayOf< Location, LocationLink >( context, data );
         }
         else
         {
-            Content::validateTypeIsObject( context, data );
+            Json::validateTypeIsObject( context, data );
             Location::validate( data );
         }
     }
@@ -5494,8 +5491,8 @@ u1 ReferenceContext::includeDeclaration( void ) const
 void ReferenceContext::validate( const Data& data )
 {
     static const auto context = CONTENT + " ReferenceContext:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::includeDeclaration, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::includeDeclaration, true );
 }
 
 //
@@ -5525,8 +5522,8 @@ ReferenceContext ReferenceParams::context( void ) const
 void ReferenceParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ReferenceParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< ReferenceContext >( context, data, Identifier::context, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< ReferenceContext >( context, data, Identifier::context, true );
 }
 
 //
@@ -5557,7 +5554,7 @@ void ReferenceResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< Location >( context, data );
+        Json::validateTypeIsArrayOf< Location >( context, data );
     }
 }
 
@@ -5636,8 +5633,8 @@ std::vector< std::string > CodeActionOptions::codeActionKinds( void ) const
 void CodeActionOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeActionOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOfString( context, data, Identifier::codeActionKinds, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOfString( context, data, Identifier::codeActionKinds, false );
 }
 
 //
@@ -5727,8 +5724,8 @@ Diagnostics CodeActionContext::diagnostics( void ) const
 void CodeActionContext::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeActionContext:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsArrayOf< TextDocumentContentChangeEvent >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsArrayOf< TextDocumentContentChangeEvent >(
         context, data, Identifier::diagnostics, true );
 }
 
@@ -5772,11 +5769,11 @@ CodeActionContext CodeActionParams::context( void ) const
 void CodeActionParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeActionParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIs< CodeActionContext >( context, data, Identifier::context, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIs< CodeActionContext >( context, data, Identifier::context, true );
 }
 
 //
@@ -5812,7 +5809,7 @@ void CodeActionResult::addCommand( const Command& command )
 void CodeActionResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeActionResult:";
-    Content::validateTypeIsMixedArrayOf< Command, CodeAction >( context, data );
+    Json::validateTypeIsMixedArrayOf< Command, CodeAction >( context, data );
 }
 
 //
@@ -5942,13 +5939,12 @@ Command CodeAction::command( void ) const
 void CodeAction::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeAction:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::title, true );
-    Content::validatePropertyIsString( context, data, Identifier::kind, false );
-    Content::validatePropertyIsArrayOf< Diagnostic >(
-        context, data, Identifier::diagnostics, false );
-    Content::validatePropertyIs< WorkspaceEdit >( context, data, Identifier::edit, false );
-    Content::validatePropertyIs< Command >( context, data, Identifier::command, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::title, true );
+    Json::validatePropertyIsString( context, data, Identifier::kind, false );
+    Json::validatePropertyIsArrayOf< Diagnostic >( context, data, Identifier::diagnostics, false );
+    Json::validatePropertyIs< WorkspaceEdit >( context, data, Identifier::edit, false );
+    Json::validatePropertyIs< Command >( context, data, Identifier::command, false );
 }
 
 //
@@ -5988,10 +5984,9 @@ Data PublishDiagnosticsParams::diagnostics( void ) const
 void PublishDiagnosticsParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " PublishDiagnosticsParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsUri( context, data, Identifier::uri, true );
-    Content::validatePropertyIsArrayOf< Diagnostic >(
-        context, data, Identifier::diagnostics, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsUri( context, data, Identifier::uri, true );
+    Json::validatePropertyIsArrayOf< Diagnostic >( context, data, Identifier::diagnostics, true );
 }
 
 //
@@ -6030,9 +6025,9 @@ void MarkedString::validate( const Data& data )
     }
 
     static const auto context = CONTENT + " MarkedString:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::language, true );
-    Content::validatePropertyIsString( context, data, Identifier::value, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::language, true );
+    Json::validatePropertyIsString( context, data, Identifier::value, true );
 }
 
 //
@@ -6091,26 +6086,25 @@ void HoverResult::validate( const Data& data )
     else
     {
         static const auto context = CONTENT + " HoverResult:";
-        Content::validateTypeIsObject( context, data );
+        Json::validateTypeIsObject( context, data );
         try
         {
-            Content::validatePropertyIs< MarkedString >(
-                context, data, Identifier::contents, true );
+            Json::validatePropertyIs< MarkedString >( context, data, Identifier::contents, true );
         }
         catch( std::invalid_argument a )
         {
             try
             {
-                Content::validatePropertyIs< MarkupContent >(
+                Json::validatePropertyIs< MarkupContent >(
                     context, data, Identifier::contents, true );
             }
             catch( std::invalid_argument a )
             {
-                Content::validatePropertyIsArrayOf< MarkedString >(
+                Json::validatePropertyIsArrayOf< MarkedString >(
                     context, data, Identifier::contents, true );
             }
         }
-        Content::validatePropertyIs< Range >( context, data, Identifier::range, false );
+        Json::validatePropertyIs< Range >( context, data, Identifier::range, false );
     }
 }
 
@@ -6150,7 +6144,7 @@ Data DefinitionResult::locations( void ) const
 void DefinitionResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " DefinitionResult:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data.find( Identifier::location ) != data.end() )
     {
         if( data[ Identifier::location ].is_null() )
@@ -6162,14 +6156,13 @@ void DefinitionResult::validate( const Data& data )
             if( data[ Identifier::location ].is_array() )
             {
                 // object is an Array
-                Content::validatePropertyIsArrayOf< Location >(
+                Json::validatePropertyIsArrayOf< Location >(
                     context, data, Identifier::location, true );
             }
             else
             {
                 // object is a single Location object
-                Content::validatePropertyIs< Location >(
-                    context, data, Identifier::location, true );
+                Json::validatePropertyIs< Location >( context, data, Identifier::location, true );
             }
         }
     }
@@ -6214,9 +6207,9 @@ void DocumentHighlight::setKind( const DocumentHighlightKind kind )
 void DocumentHighlight::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentHighlight:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, false );
 }
 
 //
@@ -6247,14 +6240,14 @@ DocumentHighlightResult::DocumentHighlightResult( const DocumentHighlights& high
 void DocumentHighlightResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " DefinitionResult:";
-    Content::validateTypeIsObject( context, data );
+    Json::validateTypeIsObject( context, data );
     if( data.is_null() )
     {
         // if it is null, do nothing
     }
     else
     {
-        Content::validateTypeIsArrayOf< DocumentHighlight >( context, data );
+        Json::validateTypeIsArrayOf< DocumentHighlight >( context, data );
     }
 }
 
@@ -6283,8 +6276,8 @@ TextDocumentIdentifier DocumentSymbolParams::textDocument( void ) const
 void DocumentSymbolParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentSymbolParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 
@@ -6324,7 +6317,7 @@ void DocumentSymbolResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< DocumentSymbol, SymbolInformation >( context, data );
+        Json::validateTypeIsArrayOf< DocumentSymbol, SymbolInformation >( context, data );
     }
 }
 
@@ -6425,15 +6418,14 @@ void DocumentSymbol::addChild( const DocumentSymbol& symbol )
 void DocumentSymbol::validate( const Data& data )
 {
     static const auto context = CONTENT + "DocumentSymbol:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::selectionRange, true );
-    Content::validatePropertyIsString( context, data, Identifier::name, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::kind, true );
-    Content::validatePropertyIsArrayOf< DocumentSymbol >(
-        context, data, Identifier::children, false );
-    Content::validatePropertyIsString( context, data, Identifier::detail, false );
-    Content::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::selectionRange, true );
+    Json::validatePropertyIsString( context, data, Identifier::name, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::kind, true );
+    Json::validatePropertyIsArrayOf< DocumentSymbol >( context, data, Identifier::children, false );
+    Json::validatePropertyIsString( context, data, Identifier::detail, false );
+    Json::validatePropertyIsBoolean( context, data, Identifier::deprecated, false );
 }
 
 //
@@ -6461,8 +6453,8 @@ TextDocumentIdentifier CodeLensParams::textDocument( void ) const
 void CodeLensParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeLensParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 
@@ -6521,9 +6513,9 @@ void CodeLens::setData( const Data& data )
 void CodeLens::validate( const Data& data )
 {
     static const auto context = CONTENT + " CodeLens:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIs< Command >( context, data, Identifier::command, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIs< Command >( context, data, Identifier::command, false );
 }
 
 //
@@ -6560,7 +6552,7 @@ void CodeLensResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< CodeLens >( context, data );
+        Json::validateTypeIsArrayOf< CodeLens >( context, data );
     }
 }
 
@@ -6605,9 +6597,9 @@ void ExecuteCommandParams::addArgument( const Data& argument )
 void ExecuteCommandParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ExecuteCommandParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::command, true );
-    Content::validatePropertyIsArray( context, data, Identifier::arguments, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::command, true );
+    Json::validatePropertyIsArray( context, data, Identifier::arguments, false );
 }
 
 //
@@ -6634,8 +6626,8 @@ TextDocumentIdentifier DocumentLinkParams::textDocument( void ) const
 void DocumentLinkParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentLinkParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 
@@ -6694,9 +6686,9 @@ Data DocumentLink::data( void ) const
 void DocumentLink::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentLink:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIsString( context, data, Identifier::target, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIsString( context, data, Identifier::target, false );
 }
 
 //
@@ -6732,7 +6724,7 @@ void DocumentLinkResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< DocumentLink >( data, context );
+        Json::validateTypeIsArrayOf< DocumentLink >( data, context );
     }
 }
 
@@ -6761,8 +6753,8 @@ TextDocumentIdentifier DocumentColorParams::textDocument( void ) const
 void DocumentColorParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentColorParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 //
@@ -6807,11 +6799,11 @@ float Color::alpha( void ) const
 void Color::validate( const Data& data )
 {
     static const auto context = CONTENT + " Color:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsNumber( context, data, Identifier::red, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::green, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::blue, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::alpha, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsNumber( context, data, Identifier::red, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::green, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::blue, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::alpha, true );
 }
 //
 //
@@ -6843,9 +6835,9 @@ Color ColorInformation::color( void ) const
 void ColorInformation::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorInformation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-    Content::validatePropertyIs< Color >( context, data, Identifier::color, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validatePropertyIs< Color >( context, data, Identifier::color, true );
 }
 
 //
@@ -6870,7 +6862,7 @@ DocumentColorResult::DocumentColorResult( const ColorInformations& colorInformat
 void DocumentColorResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorInformation:";
-    Content::validateTypeIsArrayOf< ColorInformation >( context, data );
+    Json::validateTypeIsArrayOf< ColorInformation >( context, data );
 }
 
 //
@@ -6904,9 +6896,9 @@ Range ColorPresentationParams::range( void ) const
 void ColorPresentationParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorPresentationParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Color >( context, data, Identifier::color, true );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Color >( context, data, Identifier::color, true );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
 }
 
 ColorPresentation::ColorPresentation( const Data& data )
@@ -6968,10 +6960,10 @@ TextEdits ColorPresentation::additionalTextEdits( void ) const
 void ColorPresentation::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorPresentation:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::label, true );
-    Content::validatePropertyIs< TextEdit >( context, data, Identifier::textEdit, false );
-    Content::validatePropertyIsArrayOf< TextEdit >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::label, true );
+    Json::validatePropertyIs< TextEdit >( context, data, Identifier::textEdit, false );
+    Json::validatePropertyIsArrayOf< TextEdit >(
         context, data, Identifier::additionalTextEdits, false );
 }
 
@@ -6993,7 +6985,7 @@ ColorPresentationResult::ColorPresentationResult( ColorPresentations presentatio
 void ColorPresentationResult::validate( const Data& data )
 {
     static const auto context = CONTENT + " ColorPresentationResult:";
-    Content::validateTypeIsArrayOf< ColorPresentation >( context, data );
+    Json::validateTypeIsArrayOf< ColorPresentation >( context, data );
 }
 
 //
@@ -7027,10 +7019,10 @@ FormattingOptions DocumentFormattingParams::options( void ) const
 void DocumentFormattingParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentFormattingParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIs< FormattingOptions >( context, data, Identifier::options, true );
+    Json::validatePropertyIs< FormattingOptions >( context, data, Identifier::options, true );
 }
 
 //
@@ -7093,9 +7085,9 @@ u1 FormattingOptions::insertSpaces( void ) const
 void FormattingOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " FormattingOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsNumber( context, data, Identifier::tabSize, true );
-    Content::validatePropertyIsBoolean( context, data, Identifier::insertSpaces, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsNumber( context, data, Identifier::tabSize, true );
+    Json::validatePropertyIsBoolean( context, data, Identifier::insertSpaces, true );
     validateAdditionalOptions( data );
 }
 //
@@ -7128,7 +7120,7 @@ void DocumentFormattingResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< TextEdit >( context, data );
+        Json::validateTypeIsArrayOf< TextEdit >( context, data );
     }
 }
 
@@ -7155,8 +7147,8 @@ Range DocumentRangeFormattingParams::range( void ) const
 void DocumentRangeFormattingParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentRangeFormattingParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
 }
 //
 //
@@ -7192,9 +7184,9 @@ std::string DocumentOnTypeFormattingParams::ch( void ) const
 void DocumentOnTypeFormattingParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentOnTypeFormattingParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< Position >( context, data, Identifier::position, true );
-    Content::validatePropertyIsString( context, data, Identifier::ch, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< Position >( context, data, Identifier::position, true );
+    Json::validatePropertyIsString( context, data, Identifier::ch, true );
 }
 
 //
@@ -7248,10 +7240,9 @@ std::vector< std::string > DocumentOnTypeFormattingRegistrationOptions::moreTrig
 void DocumentOnTypeFormattingRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " DocumentOnTypeFormattingRegistrationOptions:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::firstTriggerCharacter, true );
-    Content::validatePropertyIsArrayOfString(
-        context, data, Identifier::moreTriggerCharacter, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::firstTriggerCharacter, true );
+    Json::validatePropertyIsArrayOfString( context, data, Identifier::moreTriggerCharacter, true );
 }
 
 //
@@ -7293,11 +7284,11 @@ std::string RenameParams::newName( void ) const
 void RenameParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " RenameParams:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-    Content::validatePropertyIs< Position >( context, data, Identifier::position, true );
-    Content::validatePropertyIsString( context, data, Identifier::newName, true );
+    Json::validatePropertyIs< Position >( context, data, Identifier::position, true );
+    Json::validatePropertyIsString( context, data, Identifier::newName, true );
 }
 
 RenameRegistrationOptions::RenameRegistrationOptions( const Data& data )
@@ -7329,8 +7320,8 @@ u1 RenameRegistrationOptions::prepareProvider( void ) const
 void RenameRegistrationOptions::validate( const Data& data )
 {
     static const auto context = CONTENT + " RenameRegistrationOptions";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsBoolean( context, data, Identifier::prepareProvider, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsBoolean( context, data, Identifier::prepareProvider, false );
 }
 
 //
@@ -7403,9 +7394,9 @@ void PrepareRenameResult::validate( const Data& data )
         }
         catch( std::invalid_argument a )
         {
-            Content::validateTypeIsObject( context, data );
-            Content::validatePropertyIs< Range >( context, data, Identifier::range, true );
-            Content::validatePropertyIsString( context, data, Identifier::placeholder, true );
+            Json::validateTypeIsObject( context, data );
+            Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
+            Json::validatePropertyIsString( context, data, Identifier::placeholder, true );
         }
     }
 }
@@ -7434,8 +7425,8 @@ TextDocumentIdentifier FoldingRangeParams::textDocument( void ) const
 void FoldingRangeParams::validate( const Data& data )
 {
     static const auto context = CONTENT + " FoldingRangeParams";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIs< TextDocumentIdentifier >(
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
 }
 
@@ -7531,12 +7522,12 @@ std::string FoldingRange::kind( void ) const
 void FoldingRange::validate( const Data& data )
 {
     static const auto context = CONTENT + " FoldingRange";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsNumber( context, data, Identifier::startLine, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::endLine, true );
-    Content::validatePropertyIsNumber( context, data, Identifier::startCharacter, false );
-    Content::validatePropertyIsNumber( context, data, Identifier::endCharacter, false );
-    Content::validatePropertyIsString( context, data, Identifier::kind, false );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsNumber( context, data, Identifier::startLine, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::endLine, true );
+    Json::validatePropertyIsNumber( context, data, Identifier::startCharacter, false );
+    Json::validatePropertyIsNumber( context, data, Identifier::endCharacter, false );
+    Json::validatePropertyIsString( context, data, Identifier::kind, false );
 }
 
 //
@@ -7572,7 +7563,7 @@ void FoldingRangeResult::validate( const Data& data )
     }
     else
     {
-        Content::validateTypeIsArrayOf< FoldingRange >( context, data );
+        Json::validateTypeIsArrayOf< FoldingRange >( context, data );
     }
 }
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -680,6 +680,7 @@ void CreateFile::validate( const Data& data )
     Json::validatePropertyIsString( context, data, Identifier::uri, true );
     Json::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
 }
+
 //
 //
 // RenameFile

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -220,11 +220,13 @@ void Location::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsUri( context, data, Identifier::uri, true );
     Json::validatePropertyIs< Range >( context, data, Identifier::range, false );
-}
+} 
+
 //
 //
 // DiagnosticRelatedInformation
 //
+
 DiagnosticRelatedInformation::DiagnosticRelatedInformation( const Data& data )
 : Data( data )
 {
@@ -255,7 +257,8 @@ void DiagnosticRelatedInformation::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< Location >( context, data, Identifier::location, true );
     Json::validatePropertyIsString( context, data, Identifier::message, true );
-}
+} 
+
 //
 //
 // Diagnostic
@@ -628,7 +631,8 @@ void CreateFileOptions::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
     Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
-}
+} 
+
 //
 //
 // CreateFile
@@ -738,7 +742,8 @@ void RenameFile::validate( const Data& data )
     Json::validatePropertyIsString( context, data, Identifier::newUri, true );
     Json::validatePropertyIsString( context, data, Identifier::oldUri, true );
     Json::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
-}
+} 
+
 //
 //
 // DeleteFileOptions
@@ -786,11 +791,13 @@ void DeleteFileOptions::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsBoolean( context, data, Identifier::recursive, false );
     Json::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
-}
+} 
+
 //
 //
 //  DeleteFile
 //
+
 DeleteFile::DeleteFile( const Data& data )
 : Data( data )
 {
@@ -2071,6 +2078,7 @@ void DocumentOnTypeFormattingOptions::validate( const Data& data )
 //
 // RenameOptions
 //
+
 RenameOptions::RenameOptions( const Data& data )
 : Data( data )
 {
@@ -2142,6 +2150,7 @@ void ExecuteCommandOptions::validate( const Data& data )
 //
 // StaticRegistrationOptions
 //
+
 StaticRegistrationOptions::StaticRegistrationOptions( const Data& data )
 : Data( data )
 {
@@ -2174,6 +2183,7 @@ void StaticRegistrationOptions::validate( const Data& data )
 //
 // TypeDefinitionProvider
 //
+
 TypeDefinitionProvider::TypeDefinitionProvider( const Data& data )
 : Data( data )
 {
@@ -2218,6 +2228,7 @@ void TypeDefinitionProvider::validate( const Data& data )
 //
 // ColorProviderOptions
 //
+
 ColorProviderOptions::ColorProviderOptions( const Data& data )
 : Data( data )
 {
@@ -2234,6 +2245,7 @@ void ColorProviderOptions::validate( const Data& data )
 //
 // ColorProvider
 //
+
 ColorProvider::ColorProvider( const Data& data )
 : Data( data )
 {
@@ -2321,6 +2333,7 @@ void Workspace::setWorkspaceFolders( const Workspace::WorkspaceFolders& workspac
 //
 // WorkspaceFolders
 //
+
 Workspace::WorkspaceFolders::WorkspaceFolders( const Data& data )
 : Data( data )
 {
@@ -2981,6 +2994,7 @@ void InitializeError::validate( const Data& data )
 //
 // CancelParams
 //
+
 CancelParams::CancelParams( const Data& data )
 : Data( data )
 {
@@ -3260,6 +3274,7 @@ void Registration::validate( const Data& data )
 //
 // RegistrationParams
 //
+
 RegistrationParams::RegistrationParams( const Data& data )
 : Data( data )
 {
@@ -3584,7 +3599,8 @@ void WorkspaceFoldersChangeEvent::validate( const Data& data )
 
     Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::added, true );
     Json::validatePropertyIsArrayOf< WorkspaceFolder >( context, data, Identifier::removed, true );
-}
+} 
+
 //
 //
 // DidChangeWorkspaceFoldersParams
@@ -3699,6 +3715,7 @@ void ConfigurationItem::validate( const Data& data )
 //
 // ConfigurationResult
 //
+
 ConfigurationResult::ConfigurationResult( void )
 : Data( Data::array() )
 {
@@ -3958,6 +3975,7 @@ void WorkspaceSymbolParams::validate( const Data& data )
 //
 // SymbolInformation
 //
+
 SymbolInformation::SymbolInformation(
     const std::string& name, const SymbolKind kind, const Location& location )
 : Data( Data::object() )
@@ -4033,6 +4051,7 @@ void SymbolInformation::validate( const Data& data )
 //
 // workspaceSymbolResult
 //
+
 WorkspaceSymbolResult::WorkspaceSymbolResult( const Data& data )
 : Data( data )
 {
@@ -4076,7 +4095,8 @@ void WorkspaceSymbolResult::validate( const Data& data )
     {
         Json::validateTypeIsArrayOf< SymbolInformation >( context, data );
     }
-}
+} 
+
 //
 //
 // ApplyWorkspaceEditParams
@@ -4126,6 +4146,7 @@ void ApplyWorkspaceEditParams::validate( const Data& data )
 //
 // ApplyWorkspaceEditResult
 //
+
 ApplyWorkspaceEditResult::ApplyWorkspaceEditResult( const Data& data )
 : Data( data )
 {
@@ -4541,6 +4562,7 @@ void CompletionParams::validate( const Data& data )
 //
 //  CompletionItem
 //
+
 CompletionItem::CompletionItem( const Data& data )
 : Data( data )
 {
@@ -4859,11 +4881,13 @@ void CompletionList::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIsArrayOf< CompletionItem >( context, data, Identifier::items, true );
     Json::validatePropertyIsBoolean( context, data, Identifier::isIncomplete, true );
-}
+} 
+
 //
 //
 // CompletionResult
 //
+
 CompletionResult::CompletionResult( void )
 : Data( Data() )
 {
@@ -5033,6 +5057,7 @@ void MarkupContent::validate( const Data& data )
 //
 // ParameterInformation
 //
+
 ParameterInformation::ParameterInformation( const Data& data )
 : Data( data )
 {
@@ -5214,11 +5239,13 @@ void SignatureHelp::validate( const Data& data )
         context, data, Identifier::signatures, true );
     Json::validatePropertyIsNumber( context, data, Identifier::activeSignature, false );
     Json::validatePropertyIsNumber( context, data, Identifier::activeParameter, false );
-}
+} 
+
 //
 //
 // SignatureHelpResult
 //
+
 SignatureHelpResult::SignatureHelpResult( void )
 : Data( Data() )
 {
@@ -5245,11 +5272,13 @@ void SignatureHelpResult::validate( const Data& data )
     {
         SignatureHelp::validate( data );
     }
-}
+} 
+
 //
 //
 // LocationLink
 //
+
 LocationLink::LocationLink( const Data& data )
 : Data( data )
 {
@@ -5311,7 +5340,8 @@ void LocationLink::validate( const Data& data )
     Json::validatePropertyIs< Range >( context, data, Identifier::targetRange, true );
     Json::validatePropertyIs< Range >( context, data, Identifier::originSelectionRange, false );
     Json::validatePropertyIs< Range >( context, data, Identifier::targetSelectionRange, false );
-}
+} 
+
 //
 //
 // TextDocumentSaveRegistrationOptions
@@ -5500,6 +5530,7 @@ void ReferenceContext::validate( const Data& data )
 //
 // ReferenceParams
 //
+
 ReferenceParams::ReferenceParams( const Data& data )
 : TextDocumentPositionParams( data )
 {
@@ -5531,6 +5562,7 @@ void ReferenceParams::validate( const Data& data )
 //
 // ReferenceResult
 //
+
 ReferenceResult::ReferenceResult( const Data& data )
 : Data( data )
 {
@@ -5563,6 +5595,7 @@ void ReferenceResult::validate( const Data& data )
 //
 // CodeActionOptions
 //
+
 CodeActionOptions::CodeActionOptions( const Data& data )
 : Data( data )
 {
@@ -6178,6 +6211,7 @@ void DefinitionResult::validate( const Data& data )
 //
 // DocumentHighlight
 //
+
 DocumentHighlight::DocumentHighlight( const Data& data )
 : Data( data )
 {
@@ -6326,6 +6360,7 @@ void DocumentSymbolResult::validate( const Data& data )
 //
 // DocumentSymbol
 //
+
 DocumentSymbol::DocumentSymbol( const Data& data )
 : Data( data )
 {
@@ -6607,6 +6642,7 @@ void ExecuteCommandParams::validate( const Data& data )
 //
 // DocumentLinkParams
 //
+
 DocumentLinkParams::DocumentLinkParams( const Data& data )
 : Data( data )
 {
@@ -6696,6 +6732,7 @@ void DocumentLink::validate( const Data& data )
 //
 // DocumentLinkResult
 //
+
 DocumentLinkResult::DocumentLinkResult( void )
 : Data()
 {
@@ -6757,7 +6794,8 @@ void DocumentColorParams::validate( const Data& data )
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< TextDocumentIdentifier >(
         context, data, Identifier::textDocument, true );
-}
+} 
+
 //
 // Color
 //
@@ -6805,7 +6843,8 @@ void Color::validate( const Data& data )
     Json::validatePropertyIsNumber( context, data, Identifier::green, true );
     Json::validatePropertyIsNumber( context, data, Identifier::blue, true );
     Json::validatePropertyIsNumber( context, data, Identifier::alpha, true );
-}
+} 
+
 //
 //
 // ColorInformation
@@ -6845,6 +6884,7 @@ void ColorInformation::validate( const Data& data )
 //
 // DocumentColorResult
 //
+
 DocumentColorResult::DocumentColorResult( const Data& data )
 : Data( data )
 {
@@ -6870,6 +6910,7 @@ void DocumentColorResult::validate( const Data& data )
 //
 // ColorPresentationParams
 //
+
 ColorPresentationParams::ColorPresentationParams( const Data& data )
 : DocumentColorParams( data )
 {
@@ -6993,6 +7034,7 @@ void ColorPresentationResult::validate( const Data& data )
 //
 // DocumentFormattingParams
 //
+
 DocumentFormattingParams::DocumentFormattingParams( const Data& data )
 : Data( data )
 {
@@ -7030,6 +7072,7 @@ void DocumentFormattingParams::validate( const Data& data )
 //
 // FormattingOptions
 //
+
 FormattingOptions::FormattingOptions( const Data& data )
 : Data( Data::object() )
 {
@@ -7090,11 +7133,13 @@ void FormattingOptions::validate( const Data& data )
     Json::validatePropertyIsNumber( context, data, Identifier::tabSize, true );
     Json::validatePropertyIsBoolean( context, data, Identifier::insertSpaces, true );
     validateAdditionalOptions( data );
-}
+} 
+
 //
 //
 // DocumentFormattingResult
 //
+
 DocumentFormattingResult::DocumentFormattingResult( void )
 : Data()
 {
@@ -7150,11 +7195,13 @@ void DocumentRangeFormattingParams::validate( const Data& data )
     static const auto context = CONTENT + " DocumentRangeFormattingParams:";
     Json::validateTypeIsObject( context, data );
     Json::validatePropertyIs< Range >( context, data, Identifier::range, true );
-}
+} 
+
 //
 //
 // DocumentOnTypeFormattingParams
 //
+
 DocumentOnTypeFormattingParams::DocumentOnTypeFormattingParams( const Data& data )
 : DocumentFormattingParams( data )
 {
@@ -7194,6 +7241,7 @@ void DocumentOnTypeFormattingParams::validate( const Data& data )
 //
 // DocumentOnTypeFormattingRegistrationOptions
 //
+
 DocumentOnTypeFormattingRegistrationOptions::DocumentOnTypeFormattingRegistrationOptions(
     const Data& data )
 : TextDocumentRegistrationOptions( data )
@@ -7250,6 +7298,7 @@ void DocumentOnTypeFormattingRegistrationOptions::validate( const Data& data )
 //
 // RenameParams
 //
+
 RenameParams::RenameParams( const Data& data )
 : Data( data )
 {
@@ -7329,6 +7378,7 @@ void RenameRegistrationOptions::validate( const Data& data )
 //
 // RenameResult
 //
+
 RenameResult::RenameResult( void )
 : Data()
 {
@@ -7362,6 +7412,7 @@ void RenameResult::validate( const Data& data )
 //
 // PrepareRenameResult
 //
+
 PrepareRenameResult::PrepareRenameResult( void )
 : Data()
 {
@@ -7406,6 +7457,7 @@ void PrepareRenameResult::validate( const Data& data )
 //
 // FoldingRangeParams
 //
+
 FoldingRangeParams::FoldingRangeParams( const Data& data )
 : Data( data )
 {
@@ -7435,6 +7487,7 @@ void FoldingRangeParams::validate( const Data& data )
 //
 // FoldingRange
 //
+
 FoldingRange::FoldingRange( const Data& data )
 : Data( data )
 {
@@ -7535,6 +7588,7 @@ void FoldingRange::validate( const Data& data )
 //
 // FoldingRangeResult
 //
+
 FoldingRangeResult::FoldingRangeResult( void )
 : Data()
 {
@@ -7577,3 +7631,4 @@ void FoldingRangeResult::validate( const Data& data )
 //  End:
 //  vim:noexpandtab:sw=4:ts=4:
 //
+

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2335,6 +2335,109 @@ void ColorProvider::validate( const Data& data )
         }
     }
 }
+
+//
+//
+// Workspace
+//
+
+Workspace::Workspace( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+void Workspace::validate( const Data& data )
+{
+    static const auto context = CONTENT + " Workspace:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIs< Workspace::WorkspaceFolders >(
+        context, data, Identifier::workspaceFolders, false );
+}
+
+Workspace::WorkspaceFolders Workspace::workspaceFolders( void ) const
+{
+    return at( Identifier::workspaceFolders );
+}
+
+u1 Workspace::hasWorkspaceFolders( void ) const
+{
+    return find( Identifier::workspaceFolders ) != end();
+}
+
+void Workspace::setWorkspaceFolders( const Workspace::WorkspaceFolders& workspaceFolders )
+{
+    operator[]( Identifier::workspaceFolders ) =
+        Data::from_cbor( Data::to_cbor( workspaceFolders ) );
+}
+
+//
+//
+// WorkspaceFolders
+//
+Workspace::WorkspaceFolders::WorkspaceFolders( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 Workspace::WorkspaceFolders::supported( void ) const
+{
+    return at( Identifier::supported );
+}
+
+u1 Workspace::WorkspaceFolders::hasSupported( void ) const
+{
+    return find( Identifier::supported ) != end();
+}
+
+void Workspace::WorkspaceFolders::setSupported( const u1 supported )
+{
+    operator[]( Identifier::supported ) = supported;
+}
+
+void Workspace::WorkspaceFolders::setChangeNotifications( const std::string& changeNotifications )
+{
+    operator[]( Identifier::changeNotifications ) = changeNotifications;
+}
+
+void Workspace::WorkspaceFolders::setChangeNotifications( const u1 changeNotifications )
+{
+    operator[]( Identifier::changeNotifications ) = changeNotifications;
+}
+
+u1 Workspace::WorkspaceFolders::hasChangeNotifications( void ) const
+{
+    return find( Identifier::changeNotifications ) != end();
+}
+
+std::string Workspace::WorkspaceFolders::changeNotifications( void ) const
+{
+    if( at( Identifier::changeNotifications ).is_boolean() )
+    {
+        return std::to_string( operator[]( Identifier::changeNotifications ).get< u1 >() );
+    }
+    else
+    {
+        return operator[]( Identifier::changeNotifications ).get< std::string >();
+    }
+}
+
+void Workspace::WorkspaceFolders::validate( const Data& data )
+{
+    static const auto context = CONTENT + " Workspace::WorkspaceFolders:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsBoolean( context, data, Identifier::supported, false );
+    try
+    {
+        Content::validatePropertyIsString( context, data, Identifier::changeNotifications, false );
+    }
+    catch( std::invalid_argument a )
+    {
+        Content::validatePropertyIsBoolean( context, data, Identifier::changeNotifications, false );
+    }
+}
+
 //
 //
 // ServerCapabilities

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -2267,6 +2267,74 @@ void TypeDefinitionProvider::validate( const Data& data )
         StaticRegistrationOptions::validate( data );
     }
 }
+
+//
+//
+// ColorProviderOptions
+//
+ColorProviderOptions::ColorProviderOptions( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+void ColorProviderOptions::validate( const Data& data )
+{
+    static const auto context = CONTENT + " ColorProviderOptions:";
+    Content::validateTypeIsObject( context, data );
+}
+
+//
+//
+// ColorProvider
+//
+ColorProvider::ColorProvider( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+u1 ColorProvider::hasId( void ) const
+{
+    return find( Identifier::id ) != end();
+}
+
+std::string ColorProvider::id( void ) const
+{
+    return at( Identifier::id ).get< std::string >();
+}
+
+void ColorProvider::setId( std::string id )
+{
+    operator[]( Identifier::id ) = id;
+}
+
+DocumentSelector ColorProvider::documentSelector( void ) const
+{
+    return operator[]( Identifier::documentSelector );
+}
+
+void ColorProvider::validate( const Data& data )
+{
+    static const auto context = CONTENT + " ColorProvider:";
+    if( data.is_boolean() )
+    {
+        // ok, do nothing
+    }
+    else
+    {
+        try
+        {
+            ColorProviderOptions::validate( data );
+        }
+        catch( std::invalid_argument a )
+        {
+            TextDocumentRegistrationOptions::validate( data );
+            StaticRegistrationOptions::validate( data );
+            ColorProviderOptions::validate( data );
+        }
+    }
+}
 //
 //
 // ServerCapabilities
@@ -2566,6 +2634,37 @@ DocumentLinkOptions ServerCapabilities::documentLinkProvider( void ) const
 void ServerCapabilities::setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider )
 {
     operator[]( Identifier::documentLinkProvider ) = documentLinkProvider;
+}
+
+u1 ServerCapabilities::hasColorProvider( void ) const
+{
+    return find( Identifier::colorProvider ) != end();
+}
+
+ColorProvider ServerCapabilities::colorProvider( void ) const
+{
+    return at( Identifier::colorProvider );
+}
+
+void ServerCapabilities::setColorProvider( const ColorProvider& colorProvider )
+{
+    operator[]( Identifier::colorProvider ) = Data::from_cbor( Data::to_cbor( colorProvider ) );
+}
+
+u1 ServerCapabilities::hasFoldingRangeProvider( void ) const
+{
+    return find( Identifier::foldingRangeProvider ) != end();
+}
+
+FoldingRangeProvider ServerCapabilities::foldingRangeProvider( void ) const
+{
+    return at( Identifier::foldingRangeProvider );
+}
+
+void ServerCapabilities::setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider )
+{
+    operator[]( Identifier::foldingRangeProvider ) =
+        Data::from_cbor( Data::to_cbor( foldingRangeProvider ) );
 }
 
 u1 ServerCapabilities::hasExecuteCommandProvider( void ) const

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -6778,7 +6778,7 @@ RenameResult::RenameResult( const Data& data )
 }
 
 RenameResult::RenameResult( const WorkspaceEdit& edit )
-: Data( edit )
+: Data( Data::from_cbor( Data::to_cbor( edit ) ) )
 {
 }
 

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -742,6 +742,57 @@ void CreateFileOptions::validate( const Data& data )
     Content::validatePropertyIsBoolean( context, data, Identifier::overwrite, false );
     Content::validatePropertyIsBoolean( context, data, Identifier::ignoreIfExists, false );
 }
+//
+//
+// CreateFile
+//
+
+CreateFile::CreateFile( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
+
+CreateFile::CreateFile( const DocumentUri& uri )
+: Data( Data::object() )
+{
+    operator[]( Identifier::kind ) = std::string( Identifier::create );
+    operator[]( Identifier::uri ) = uri.toString();
+}
+
+DocumentUri CreateFile::uri( void ) const
+{
+    return DocumentUri::fromString( operator[]( Identifier::uri ).get< std::string >() );
+}
+
+std::string CreateFile::kind( void ) const
+{
+    return operator[]( Identifier::kind ).get< std::string >();
+}
+
+u1 CreateFile::hasOptions( void ) const
+{
+    return find( Identifier::options ) != end();
+}
+
+void CreateFile::setOptions( const CreateFileOptions& options )
+{
+    operator[]( Identifier::options ) = Data::from_cbor( Data::to_cbor( options ) );
+}
+
+CreateFileOptions CreateFile::options( void ) const
+{
+    return at( Identifier::options );
+}
+
+void CreateFile::validate( const Data& data )
+{
+    static const auto context = CONTENT + " CreateFile:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIsString( context, data, Identifier::kind, true );
+    Content::validatePropertyIsString( context, data, Identifier::uri, true );
+    Content::validatePropertyIs< CreateFileOptions >( context, data, Identifier::options, false );
+}
 
 //
 //

--- a/src/cpp/net/lsp/Content.cpp
+++ b/src/cpp/net/lsp/Content.cpp
@@ -368,7 +368,41 @@ void Location::validate( const Data& data )
     Content::validatePropertyIsUri( context, data, Identifier::uri, true );
     Content::validatePropertyIs< Range >( context, data, Identifier::range, false );
 }
+//
+//
+// DiagnosticRelatedInformation
+//
+DiagnosticRelatedInformation::DiagnosticRelatedInformation( const Data& data )
+: Data( data )
+{
+    validate( data );
+}
 
+DiagnosticRelatedInformation::DiagnosticRelatedInformation(
+    const Location& location, const std::string& message )
+: Data( Data::object() )
+{
+    operator[]( Identifier::location ) = Data::from_cbor( Data::to_cbor( location ) );
+    operator[]( Identifier::message ) = message;
+}
+
+Location DiagnosticRelatedInformation::location( void ) const
+{
+    return operator[]( Identifier::location );
+}
+
+std::string DiagnosticRelatedInformation::message( void ) const
+{
+    return operator[]( Identifier::message ).get< std::string >();
+}
+
+void DiagnosticRelatedInformation::validate( const Data& data )
+{
+    static const auto context = CONTENT + " DiagnosticRelatedInformation:";
+    Content::validateTypeIsObject( context, data );
+    Content::validatePropertyIs< Location >( context, data, Identifier::location, true );
+    Content::validatePropertyIsString( context, data, Identifier::message, true );
+}
 //
 //
 // Diagnostic

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1162,7 +1162,19 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
-            using ShowMessageRequestResult = MessageActionItem;
+            class ShowMessageRequestResult : public Data
+            {
+              public:
+                ShowMessageRequestResult( void );
+
+                ShowMessageRequestResult( const Data& data );
+
+                ShowMessageRequestResult( const MessageActionItem& item );
+
+                ShowMessageRequestResult( const std::string& title );
+
+                static void validate( const Data& data );
+            };
 
             using MessageActionItems = std::vector< MessageActionItem >;
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1037,6 +1037,7 @@ namespace libstdhl
 
                 void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
             };
+
             class ServerCapabilities : public Data
             {
               public:
@@ -1579,15 +1580,10 @@ namespace libstdhl
             enum class FileChangeType
             {
                 Created = 1,
-
                 Changed = 2,
-
                 Deleted = 3
             };
 
-            /**
-              An event describing a file change.
-             */
             class FileEvent : public Data
             {
               public:
@@ -1618,11 +1614,8 @@ namespace libstdhl
 
             enum class WatchKind
             {
-
                 Create = 1,
-
                 Change = 2,
-
                 Delete = 4
             };
 
@@ -1646,10 +1639,8 @@ namespace libstdhl
                 void setKind( const WatchKind kind );
             };
 
-            /**
-              Describe options to be used when registering for text document change events.
-             */
             using FileSystemWatchers = std::vector< FileSystemWatcher >;
+
             class DidChangeWatchedFilesRegistrationOptions : public Data
             {
               public:
@@ -1732,7 +1723,9 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             using SymbolInformations = std::vector< SymbolInformation >;
+
             class WorkspaceSymbolResult : public Data
             {
               public:
@@ -1884,6 +1877,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             class DidCloseTextDocumentParams : public Data
             {
               public:
@@ -1920,22 +1914,9 @@ namespace libstdhl
 
             enum class CompletionTriggerKind
             {
-                /**
-                 * Completion was triggered by typing an identifier (24x7 code
-                 * complete), manual invocation (e.g Ctrl+Space) or via API.
-                 */
-                Invoked = 1,
-
-                /**
-                 * Completion was triggered by a trigger character specified by
-                 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-                 */
-                TriggerCharacter = 2,
-
-                /**
-                 * Completion was re-triggered as the current completion list is incomplete.
-                 */
-                TriggerForIncompleteCompletions = 3
+                Invoked = 1,  // via API, Ctrl+Space, or typing identifier (24x7 code complete)
+                TriggerCharacter = 2,  // via triggerCharacters, see CompletionRegistrationOptions
+                TriggerForIncompleteCompletions = 3  // re-triggered due to current incomplete list
             };
 
             class CompletionContext : public Data
@@ -2129,6 +2110,7 @@ namespace libstdhl
             };
 
             using CompletionItems = std::vector< CompletionItem >;
+
             class CompletionList : public Data
             {
               public:
@@ -2180,6 +2162,7 @@ namespace libstdhl
             };
 
             using ParameterInformations = std::vector< ParameterInformation >;
+
             class SignatureInformation : public Data
             {
               public:
@@ -2205,6 +2188,7 @@ namespace libstdhl
             };
 
             using SignatureInformations = std::vector< SignatureInformation >;
+
             class SignatureHelp : public Data
             {
               public:
@@ -2317,6 +2301,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             class ReferenceResult : public Data
             {
               public:
@@ -2707,7 +2692,9 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             using DocumentLinks = std::vector< DocumentLink >;
+
             class DocumentLinkResult : public Data
             {
               public:
@@ -2768,6 +2755,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             using ColorInformations = std::vector< ColorInformation >;
 
             class DocumentColorResult : public Data
@@ -2882,6 +2870,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             class DocumentRangeFormattingParams : public DocumentFormattingParams
             {
               public:
@@ -3012,6 +3001,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             enum class FoldingRangeKind
             {
                 Comment,
@@ -3050,7 +3040,9 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             using FoldingRanges = std::vector< FoldingRange >;
+
             class FoldingRangeResult : public Data
             {
               public:
@@ -3081,7 +3073,7 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
-            using ExecuteCommandResult = Data;  // TODO: PPA: FIXME:
+            using ExecuteCommandResult = Data;  // TODO: FIXME: @ppaulweber
         }
     }
 }

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -66,644 +66,433 @@ namespace libstdhl
 
             using DocumentUri = libstdhl::Standard::RFC3986::URI;
 
-        }
-
-        enum class ErrorCode : i32
-        {
-            // defined by JSON RPC
-            ParseError = -32700,
-            InvalidRequest = -32600,
-            MethodNotFound = -32601,
-            InvalidParams = -32602,
-            InternalError = -32603,
-            serverErrorStart = -32099,
-            serverErrorEnd = -32000,
-            ServerNotInitialized = -32002,
-            UnknownErrorCode = -32001,
-
-            // defined by LSP
-            RequestCancelled = -32800,
-
-        };
-
-        class ResponseError final : public Data
-        {
-          public:
-            ResponseError( const Data& data );
-
-            ResponseError( const ErrorCode code, const std::string& message );
-
-            ErrorCode code( void ) const;
-
-            std::string message( void ) const;
-
-            u1 hasData( void ) const;
-
-            Data data( void ) const;
-
-            void setData( const Data& data );
-
-            static void validate( const Data& data );
-        };
-
-        namespace TextDocument
-        {
-            constexpr const std::array< const char*, 3 > EOL = { { "\n", "\r\n", "\r" } };
-        }
-
-        class Position : public Data
-        {
-          public:
-            Position( const Data& data );
-
-            Position( const std::size_t line, const std::size_t character );
-
-            std::size_t line( void ) const;
-
-            std::size_t character( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class Range : public Data
-        {
-          public:
-            Range( const Data& data );
-
-            Range( const Position& start, const Position& end );
-
-            Position start( void ) const;
-
-            Position end( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class Location : public Data
-        {
-          public:
-            Location( const Data& data );
-
-            Location( const DocumentUri& uri, const Range& range );
-
-            DocumentUri uri( void ) const;
-
-            Range range( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        enum class DiagnosticSeverity : std::size_t
-        {
-            Error = 1,
-            Warning = 2,
-            Information = 3,
-            Hint = 4,
-        };
-
-        class DiagnosticRelatedInformation : public Data
-        {
-          public:
-            DiagnosticRelatedInformation( const Data& data );
-
-            DiagnosticRelatedInformation( const Location& location, const std::string& message );
-
-            Location location( void ) const;
-
-            std::string message( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class Diagnostic : public Data
-        {
-          public:
-            Diagnostic( const Data& data );
-
-            Diagnostic( const Range& range, const std::string& message );
-
-            Range range( void ) const;
-
-            std::string message( void ) const;
-
-            u1 hasSeverity( void ) const;
-
-            DiagnosticSeverity severity( void ) const;
-
-            void setSeverity( const DiagnosticSeverity& severity );
-
-            u1 hasCode( void ) const;
-
-            std::string code( void ) const;
-
-            void setCode( const std::string& code );
-
-            void setCode( const std::size_t code );
-
-            u1 hasSource( void ) const;
-
-            std::string source( void ) const;
-
-            void setSource( const std::string& source );
-
-            static void validate( const Data& data );
-        };
-
-        class Command : public Data
-        {
-          public:
-            Command( const Data& data );
-
-            Command( const std::string& title, const std::string& command );
-
-            std::string title( void ) const;
-
-            std::string command( void ) const;
-
-            u1 hasArguments( void ) const;
-
-            Data arguments( void ) const;
-
-            void addArgument( const Data& argument );
-
-            static void validate( const Data& data );
-        };
-
-        class TextEdit : public Data
-        {
-          public:
-            TextEdit( const Data& data );
-
-            TextEdit( const Range& range, const std::string& newText );
-
-            Range range( void ) const;
-
-            std::string newText( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentIdentifier : public Data
-        {
-          public:
-            TextDocumentIdentifier( const Data& data );
-
-            TextDocumentIdentifier( const DocumentUri& uri );
-
-            DocumentUri uri( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class VersionedTextDocumentIdentifier : public TextDocumentIdentifier
-        {
-          public:
-            VersionedTextDocumentIdentifier( const Data& data );
-
-            VersionedTextDocumentIdentifier( const DocumentUri& uri, const std::size_t version );
-
-            std::size_t version( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentEdit : public Data
-        {
-          public:
-            TextDocumentEdit( const Data& data );
-
-            TextDocumentEdit(
-                const VersionedTextDocumentIdentifier& textDocument,
-                const std::vector< TextEdit >& edits );
-
-            VersionedTextDocumentIdentifier textDocument( void ) const;
-
-            Data edits( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class WorkspaceEdit : public Data
-        {
-          public:
-            WorkspaceEdit( const Data& data );
-
-            WorkspaceEdit( void );
-
-            // changes interface omitted!
-
-            u1 hasDocumentChanges( void ) const;
-
-            Data documentChanges( void ) const;
-
-            void addDocumentChange( const TextDocumentEdit& documentChange );
-
-            static void validate( const Data& data );
-        };
-
-        class CreateFileOptions : public Data
-        {
-          public:
-            CreateFileOptions( const Data& data );
-
-            CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists );
-
-            u1 hasOverwrite( void ) const;
-
-            u1 overwrite( void ) const;
-
-            void setOverwrite( const u1 overwrite );
-
-            u1 hasIgnoreIfExists( void ) const;
-
-            u1 ignoreIfExists( void ) const;
-
-            void setIgnoreIfExists( const u1 ignoreIfExists );
-
-            static void validate( const Data& data );
-        };
-
-        class CreateFile : public Data
-        {
-          public:
-            CreateFile( const Data& data );
-
-            CreateFile( const DocumentUri& uri );
-
-            DocumentUri uri( void ) const;
-
-            std::string kind( void ) const;
-
-            u1 hasOptions( void ) const;
-
-            void setOptions( const CreateFileOptions& options );
-
-            CreateFileOptions options( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using RenameFileOptions = CreateFileOptions;
-
-        class RenameFile : public Data
-        {
-          public:
-            RenameFile( const Data& data );
-
-            RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri );
-
-            DocumentUri newUri( void ) const;
-
-            DocumentUri oldUri( void ) const;
-
-            std::string kind( void ) const;
-
-            u1 hasOptions( void ) const;
-
-            void setOptions( const CreateFileOptions& options );
-
-            CreateFileOptions options( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DeleteFileOptions : public Data
-        {
-          public:
-            DeleteFileOptions( const Data& data );
-
-            u1 hasRecursive( void ) const;
-
-            u1 recursive( void ) const;
-
-            void setRecursive( const u1 recursive );
-
-            u1 hasIgnoreIfExists( void ) const;
-
-            u1 ignoreIfExists( void ) const;
-
-            void setIgnoreIfExists( const u1 ignoreIfExists );
-
-            static void validate( const Data& data );
-        };
-
-        class DeleteFile : public Data
-        {
-          public:
-            DeleteFile( const Data& data );
-
-            DeleteFile( const DocumentUri& uri );
-
-            DocumentUri uri( void ) const;
-
-            std::string kind( void ) const;
-
-            u1 hasOptions( void ) const;
-
-            void setOptions( const DeleteFileOptions& options );
-
-            DeleteFileOptions options( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentItem : public Data
-        {
-          public:
-            TextDocumentItem( const Data& data );
-
-            TextDocumentItem(
-                const DocumentUri& uri,
-                const std::string& languageId,
-                const std::size_t version,
-                const std::string& text );
-
-            DocumentUri uri( void ) const;
-
-            std::string languageId( void ) const;
-
-            std::size_t version( void ) const;
-
-            std::string text( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentPositionParams : public Data
-        {
-          public:
-            TextDocumentPositionParams( const Data& data );
-
-            TextDocumentPositionParams(
-                const TextDocumentIdentifier& textDocument, const Position& position );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            Position position( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentFilter : public Data
-        {
-          public:
-            DocumentFilter( const Data& data );
-
-            DocumentFilter( void );
-
-            u1 hasLanguage( void ) const;
-
-            std::string language( void ) const;
-
-            void setLanguage( const std::string& language );
-
-            u1 hasScheme( void ) const;
-
-            std::string scheme( void ) const;
-
-            void setScheme( const std::string& scheme );
-
-            u1 hasPattern( void ) const;
-
-            std::string pattern( void ) const;
-
-            void setPattern( const std::string& pattern );
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentSelector : public Data
-        {
-          public:
-            DocumentSelector( const Data& data );
-
-            DocumentSelector( const std::vector< DocumentFilter >& documentFilters );
-
-            static void validate( const Data& data );
-        };
-
-        //
-        //
-        // Actual Protocol
-        //
-
-        class DynamicRegistration : public Data
-        {
-          public:
-            DynamicRegistration( const Data& data );
-
-            DynamicRegistration( void );
-
-            u1 hasDynamicRegistration( void ) const;
-
-            u1 dynamicRegistration( void ) const;
-
-            void setDynamicRegistration( const u1 dynamicRegistration );
-
-            static void validate( const Data& data );
-        };
-
-        class WorkspaceClientCapabilities : public Data
-        {
-          public:
-            WorkspaceClientCapabilities( const Data& data );
-
-            WorkspaceClientCapabilities( void );
-
-            u1 hasApplyEdit( void ) const;
-
-            u1 applyEdit( void ) const;
-
-            void setApplyEdit( const u1 applyEdit );
-
-            u1 hasWorkspaceEdit( void ) const;
-
-            WorkspaceEdit workspaceEdit( void ) const;
-
-            void setWorkspaceEdit( const WorkspaceEdit& workspaceEdit );
-
-            u1 hasDidChangeConfiguration( void ) const;
-
-            DynamicRegistration didChangeConfiguration( void ) const;
-
-            void setDidChangeConfiguration( const DynamicRegistration& didChangeConfiguration );
-
-            u1 hasDidChangeWatchedFiles( void ) const;
-
-            DynamicRegistration didChangeWatchedFiles( void ) const;
-
-            void didChangeWatchedFiles( const DynamicRegistration& didChangeWatchedFiles );
-
-            u1 hasSymbol( void ) const;
-
-            DynamicRegistration symbol( void ) const;
-
-            void setSymbol( const DynamicRegistration& symbol );
-
-            u1 hasExecuteCommand( void ) const;
-
-            DynamicRegistration executeCommand( void ) const;
-
-            void executeCommand( const DynamicRegistration& executeCommand );
-
-            u1 hasWorkspaceFolders( void ) const;
-
-            void setWorkspaceFolders( const u1 workspaceFolders );
-
-            u1 workspaceFolders( void ) const;
-
-            u1 hasConfiguration( void ) const;
-
-            void setConfiguration( const u1 configuration );
-
-            u1 configuration( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class Synchronization : public Data
-        {
-          public:
-            Synchronization( const Data& data );
-
-            Synchronization( void );
-
-            u1 hasDynamicRegistration( void ) const;
-
-            u1 dynamicRegistration( void ) const;
-
-            void setDynamicRegistration( const u1 dynamicRegistration );
-
-            u1 hasWillSave( void ) const;
-
-            u1 willSave( void ) const;
-
-            void setWillSave( const u1 willSave );
-
-            u1 hasWillSaveWaitUntil( void ) const;
-
-            u1 willSaveWaitUntil( void ) const;
-
-            void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
-
-            u1 hasDidSave( void ) const;
-
-            u1 didSave( void ) const;
-
-            void setDidSave( const u1 didSave );
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentClientCapabilities : public Data
-        {
-            class CompletionItem;
-            class Completion;
-
-          public:
-            TextDocumentClientCapabilities( const Data& data );
-
-            TextDocumentClientCapabilities( void );
-
-            u1 hasSynchronization( void ) const;
-
-            Synchronization synchronization( void ) const;
-
-            void setSynchronization( const Synchronization& synchronization );
-
-            u1 hasCompletion( void ) const;
-
-            Completion completion( void ) const;
-
-            void setCompletion( const Completion& completion );
-
-            u1 hasHover( void ) const;
-
-            DynamicRegistration hover( void ) const;
-
-            void setHover( const DynamicRegistration& hover );
-
-            u1 hasSignatureHelp( void ) const;
-
-            DynamicRegistration signatureHelp( void ) const;
-
-            void setSignatureHelp( const DynamicRegistration& signatureHelp );
-
-            u1 hasReferences( void ) const;
-
-            DynamicRegistration references( void ) const;
-
-            void setReferences( const DynamicRegistration& references );
-
-            u1 hasDocumentHighlight( void ) const;
-
-            DynamicRegistration documentHighlight( void ) const;
-
-            void setDocumentHighlight( const DynamicRegistration& documentHighlight );
-
-            u1 hasDocumentSymbol( void ) const;
-
-            DynamicRegistration documentSymbol( void ) const;
-
-            void setDocumentSymbol( const DynamicRegistration& documentSymbol );
-
-            u1 hasFormatting( void ) const;
-
-            DynamicRegistration formatting( void ) const;
-
-            void setFormatting( const DynamicRegistration& formatting );
-
-            u1 hasRangeFormatting( void ) const;
-
-            DynamicRegistration rangeFormatting( void ) const;
-
-            void setRangeFormatting( const DynamicRegistration& rangeFormatting );
-
-            u1 hasOnTypeFormatting( void ) const;
-
-            DynamicRegistration onTypeFormatting( void ) const;
-
-            void setOnTypeFormatting( const DynamicRegistration& onTypeFormatting );
-
-            u1 hasDefinition( void ) const;
-
-            DynamicRegistration definition( void ) const;
-
-            void setDefinition( const DynamicRegistration& definition );
-
-            u1 hasCodeAction( void ) const;
-
-            DynamicRegistration codeAction( void ) const;
-
-            void setCodeAction( const DynamicRegistration& codeAction );
-
-            u1 hasCodeLens( void ) const;
-
-            DynamicRegistration codeLens( void ) const;
-
-            void setCodeLens( const DynamicRegistration& codeLens );
-
-            u1 hasDocumentLink( void ) const;
-
-            DynamicRegistration documentLink( void ) const;
-
-            void setDocumentLink( const DynamicRegistration& documentLink );
-
-            u1 hasRename( void ) const;
-
-            DynamicRegistration rename( void ) const;
-
-            void setRename( const DynamicRegistration& rename );
-
-            static void validate( const Data& data );
-
-          private:
-            class Completion : public Data
+            enum class ErrorCode : i32
+            {
+                // defined by JSON RPC
+                ParseError = -32700,
+                InvalidRequest = -32600,
+                MethodNotFound = -32601,
+                InvalidParams = -32602,
+                InternalError = -32603,
+                serverErrorStart = -32099,
+                serverErrorEnd = -32000,
+                ServerNotInitialized = -32002,
+                UnknownErrorCode = -32001,
+
+                // defined by LSP
+                RequestCancelled = -32800,
+
+            };
+
+            class ResponseError final : public Data
             {
               public:
-                Completion( const Data& data );
+                ResponseError( const Data& data );
 
-                Completion( void );
+                ResponseError( const ErrorCode code, const std::string& message );
+
+                ErrorCode code( void ) const;
+
+                std::string message( void ) const;
+
+                u1 hasData( void ) const;
+
+                Data data( void ) const;
+
+                void setData( const Data& data );
+
+                static void validate( const Data& data );
+            };
+
+            namespace TextDocument
+            {
+                constexpr const std::array< const char*, 3 > EOL = { { "\n", "\r\n", "\r" } };
+            }
+
+            class Position : public Data
+            {
+              public:
+                Position( const Data& data );
+
+                Position( const std::size_t line, const std::size_t character );
+
+                std::size_t line( void ) const;
+
+                std::size_t character( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class Range : public Data
+            {
+              public:
+                Range( const Data& data );
+
+                Range( const Position& start, const Position& end );
+
+                Position start( void ) const;
+
+                Position end( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class Location : public Data
+            {
+              public:
+                Location( const Data& data );
+
+                Location( const DocumentUri& uri, const Range& range );
+
+                DocumentUri uri( void ) const;
+
+                Range range( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class DiagnosticSeverity : std::size_t
+            {
+                Error = 1,
+                Warning = 2,
+                Information = 3,
+                Hint = 4,
+            };
+
+            class DiagnosticRelatedInformation : public Data
+            {
+              public:
+                DiagnosticRelatedInformation( const Data& data );
+
+                DiagnosticRelatedInformation(
+                    const Location& location, const std::string& message );
+
+                Location location( void ) const;
+
+                std::string message( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class Diagnostic : public Data
+            {
+              public:
+                Diagnostic( const Data& data );
+
+                Diagnostic( const Range& range, const std::string& message );
+
+                Range range( void ) const;
+
+                std::string message( void ) const;
+
+                u1 hasSeverity( void ) const;
+
+                DiagnosticSeverity severity( void ) const;
+
+                void setSeverity( const DiagnosticSeverity& severity );
+
+                u1 hasCode( void ) const;
+
+                std::string code( void ) const;
+
+                void setCode( const std::string& code );
+
+                void setCode( const std::size_t code );
+
+                u1 hasSource( void ) const;
+
+                std::string source( void ) const;
+
+                void setSource( const std::string& source );
+
+                static void validate( const Data& data );
+            };
+
+            class Command : public Data
+            {
+              public:
+                Command( const Data& data );
+
+                Command( const std::string& title, const std::string& command );
+
+                std::string title( void ) const;
+
+                std::string command( void ) const;
+
+                u1 hasArguments( void ) const;
+
+                Data arguments( void ) const;
+
+                void addArgument( const Data& argument );
+
+                static void validate( const Data& data );
+            };
+
+            class TextEdit : public Data
+            {
+              public:
+                TextEdit( const Data& data );
+
+                TextEdit( const Range& range, const std::string& newText );
+
+                Range range( void ) const;
+
+                std::string newText( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentIdentifier : public Data
+            {
+              public:
+                TextDocumentIdentifier( const Data& data );
+
+                TextDocumentIdentifier( const DocumentUri& uri );
+
+                DocumentUri uri( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class VersionedTextDocumentIdentifier : public TextDocumentIdentifier
+            {
+              public:
+                VersionedTextDocumentIdentifier( const Data& data );
+
+                VersionedTextDocumentIdentifier(
+                    const DocumentUri& uri, const std::size_t version );
+
+                std::size_t version( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentEdit : public Data
+            {
+              public:
+                TextDocumentEdit( const Data& data );
+
+                TextDocumentEdit(
+                    const VersionedTextDocumentIdentifier& textDocument,
+                    const std::vector< TextEdit >& edits );
+
+                VersionedTextDocumentIdentifier textDocument( void ) const;
+
+                Data edits( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class WorkspaceEdit : public Data
+            {
+              public:
+                WorkspaceEdit( const Data& data );
+
+                WorkspaceEdit( void );
+
+                // changes interface omitted!
+
+                u1 hasDocumentChanges( void ) const;
+
+                Data documentChanges( void ) const;
+
+                void addDocumentChange( const TextDocumentEdit& documentChange );
+
+                static void validate( const Data& data );
+            };
+
+            class CreateFileOptions : public Data
+            {
+              public:
+                CreateFileOptions( const Data& data );
+
+                CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists );
+
+                u1 hasOverwrite( void ) const;
+
+                u1 overwrite( void ) const;
+
+                void setOverwrite( const u1 overwrite );
+
+                u1 hasIgnoreIfExists( void ) const;
+
+                u1 ignoreIfExists( void ) const;
+
+                void setIgnoreIfExists( const u1 ignoreIfExists );
+
+                static void validate( const Data& data );
+            };
+
+            class CreateFile : public Data
+            {
+              public:
+                CreateFile( const Data& data );
+
+                CreateFile( const DocumentUri& uri );
+
+                DocumentUri uri( void ) const;
+
+                std::string kind( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const CreateFileOptions& options );
+
+                CreateFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using RenameFileOptions = CreateFileOptions;
+
+            class RenameFile : public Data
+            {
+              public:
+                RenameFile( const Data& data );
+
+                RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri );
+
+                DocumentUri newUri( void ) const;
+
+                DocumentUri oldUri( void ) const;
+
+                std::string kind( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const CreateFileOptions& options );
+
+                CreateFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class DeleteFileOptions : public Data
+            {
+              public:
+                DeleteFileOptions( const Data& data );
+
+                u1 hasRecursive( void ) const;
+
+                u1 recursive( void ) const;
+
+                void setRecursive( const u1 recursive );
+
+                u1 hasIgnoreIfExists( void ) const;
+
+                u1 ignoreIfExists( void ) const;
+
+                void setIgnoreIfExists( const u1 ignoreIfExists );
+
+                static void validate( const Data& data );
+            };
+
+            class DeleteFile : public Data
+            {
+              public:
+                DeleteFile( const Data& data );
+
+                DeleteFile( const DocumentUri& uri );
+
+                DocumentUri uri( void ) const;
+
+                std::string kind( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const DeleteFileOptions& options );
+
+                DeleteFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentItem : public Data
+            {
+              public:
+                TextDocumentItem( const Data& data );
+
+                TextDocumentItem(
+                    const DocumentUri& uri,
+                    const std::string& languageId,
+                    const std::size_t version,
+                    const std::string& text );
+
+                DocumentUri uri( void ) const;
+
+                std::string languageId( void ) const;
+
+                std::size_t version( void ) const;
+
+                std::string text( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentPositionParams : public Data
+            {
+              public:
+                TextDocumentPositionParams( const Data& data );
+
+                TextDocumentPositionParams(
+                    const TextDocumentIdentifier& textDocument, const Position& position );
+
+                TextDocumentIdentifier textDocument( void ) const;
+
+                Position position( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class DocumentFilter : public Data
+            {
+              public:
+                DocumentFilter( const Data& data );
+
+                DocumentFilter( void );
+
+                u1 hasLanguage( void ) const;
+
+                std::string language( void ) const;
+
+                void setLanguage( const std::string& language );
+
+                u1 hasScheme( void ) const;
+
+                std::string scheme( void ) const;
+
+                void setScheme( const std::string& scheme );
+
+                u1 hasPattern( void ) const;
+
+                std::string pattern( void ) const;
+
+                void setPattern( const std::string& pattern );
+
+                static void validate( const Data& data );
+            };
+
+            class DocumentSelector : public Data
+            {
+              public:
+                DocumentSelector( const Data& data );
+
+                DocumentSelector( const std::vector< DocumentFilter >& documentFilters );
+
+                static void validate( const Data& data );
+            };
+
+            //
+            //
+            // Actual Protocol
+            //
+
+            class DynamicRegistration : public Data
+            {
+              public:
+                DynamicRegistration( const Data& data );
+
+                DynamicRegistration( void );
 
                 u1 hasDynamicRegistration( void ) const;
 
@@ -711,2372 +500,2590 @@ namespace libstdhl
 
                 void setDynamicRegistration( const u1 dynamicRegistration );
 
-                u1 hasCompletionItem( void ) const;
+                static void validate( const Data& data );
+            };
 
-                CompletionItem completionItem( void ) const;
+            class WorkspaceClientCapabilities : public Data
+            {
+              public:
+                WorkspaceClientCapabilities( const Data& data );
 
-                void completionItem( const CompletionItem& completionItem );
+                WorkspaceClientCapabilities( void );
+
+                u1 hasApplyEdit( void ) const;
+
+                u1 applyEdit( void ) const;
+
+                void setApplyEdit( const u1 applyEdit );
+
+                u1 hasWorkspaceEdit( void ) const;
+
+                WorkspaceEdit workspaceEdit( void ) const;
+
+                void setWorkspaceEdit( const WorkspaceEdit& workspaceEdit );
+
+                u1 hasDidChangeConfiguration( void ) const;
+
+                DynamicRegistration didChangeConfiguration( void ) const;
+
+                void setDidChangeConfiguration( const DynamicRegistration& didChangeConfiguration );
+
+                u1 hasDidChangeWatchedFiles( void ) const;
+
+                DynamicRegistration didChangeWatchedFiles( void ) const;
+
+                void didChangeWatchedFiles( const DynamicRegistration& didChangeWatchedFiles );
+
+                u1 hasSymbol( void ) const;
+
+                DynamicRegistration symbol( void ) const;
+
+                void setSymbol( const DynamicRegistration& symbol );
+
+                u1 hasExecuteCommand( void ) const;
+
+                DynamicRegistration executeCommand( void ) const;
+
+                void executeCommand( const DynamicRegistration& executeCommand );
+
+                u1 hasWorkspaceFolders( void ) const;
+
+                void setWorkspaceFolders( const u1 workspaceFolders );
+
+                u1 workspaceFolders( void ) const;
+
+                u1 hasConfiguration( void ) const;
+
+                void setConfiguration( const u1 configuration );
+
+                u1 configuration( void ) const;
 
                 static void validate( const Data& data );
             };
+
+            class Synchronization : public Data
+            {
+              public:
+                Synchronization( const Data& data );
+
+                Synchronization( void );
+
+                u1 hasDynamicRegistration( void ) const;
+
+                u1 dynamicRegistration( void ) const;
+
+                void setDynamicRegistration( const u1 dynamicRegistration );
+
+                u1 hasWillSave( void ) const;
+
+                u1 willSave( void ) const;
+
+                void setWillSave( const u1 willSave );
+
+                u1 hasWillSaveWaitUntil( void ) const;
+
+                u1 willSaveWaitUntil( void ) const;
+
+                void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
+
+                u1 hasDidSave( void ) const;
+
+                u1 didSave( void ) const;
+
+                void setDidSave( const u1 didSave );
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentClientCapabilities : public Data
+            {
+                class CompletionItem;
+                class Completion;
+
+              public:
+                TextDocumentClientCapabilities( const Data& data );
+
+                TextDocumentClientCapabilities( void );
+
+                u1 hasSynchronization( void ) const;
+
+                Synchronization synchronization( void ) const;
+
+                void setSynchronization( const Synchronization& synchronization );
+
+                u1 hasCompletion( void ) const;
+
+                Completion completion( void ) const;
+
+                void setCompletion( const Completion& completion );
+
+                u1 hasHover( void ) const;
+
+                DynamicRegistration hover( void ) const;
+
+                void setHover( const DynamicRegistration& hover );
+
+                u1 hasSignatureHelp( void ) const;
+
+                DynamicRegistration signatureHelp( void ) const;
+
+                void setSignatureHelp( const DynamicRegistration& signatureHelp );
+
+                u1 hasReferences( void ) const;
+
+                DynamicRegistration references( void ) const;
+
+                void setReferences( const DynamicRegistration& references );
+
+                u1 hasDocumentHighlight( void ) const;
+
+                DynamicRegistration documentHighlight( void ) const;
+
+                void setDocumentHighlight( const DynamicRegistration& documentHighlight );
+
+                u1 hasDocumentSymbol( void ) const;
+
+                DynamicRegistration documentSymbol( void ) const;
+
+                void setDocumentSymbol( const DynamicRegistration& documentSymbol );
+
+                u1 hasFormatting( void ) const;
+
+                DynamicRegistration formatting( void ) const;
+
+                void setFormatting( const DynamicRegistration& formatting );
+
+                u1 hasRangeFormatting( void ) const;
+
+                DynamicRegistration rangeFormatting( void ) const;
+
+                void setRangeFormatting( const DynamicRegistration& rangeFormatting );
+
+                u1 hasOnTypeFormatting( void ) const;
+
+                DynamicRegistration onTypeFormatting( void ) const;
+
+                void setOnTypeFormatting( const DynamicRegistration& onTypeFormatting );
+
+                u1 hasDefinition( void ) const;
+
+                DynamicRegistration definition( void ) const;
+
+                void setDefinition( const DynamicRegistration& definition );
+
+                u1 hasCodeAction( void ) const;
+
+                DynamicRegistration codeAction( void ) const;
+
+                void setCodeAction( const DynamicRegistration& codeAction );
+
+                u1 hasCodeLens( void ) const;
+
+                DynamicRegistration codeLens( void ) const;
+
+                void setCodeLens( const DynamicRegistration& codeLens );
+
+                u1 hasDocumentLink( void ) const;
+
+                DynamicRegistration documentLink( void ) const;
+
+                void setDocumentLink( const DynamicRegistration& documentLink );
+
+                u1 hasRename( void ) const;
+
+                DynamicRegistration rename( void ) const;
+
+                void setRename( const DynamicRegistration& rename );
+
+                static void validate( const Data& data );
+
+              private:
+                class Completion : public Data
+                {
+                  public:
+                    Completion( const Data& data );
+
+                    Completion( void );
+
+                    u1 hasDynamicRegistration( void ) const;
+
+                    u1 dynamicRegistration( void ) const;
+
+                    void setDynamicRegistration( const u1 dynamicRegistration );
+
+                    u1 hasCompletionItem( void ) const;
+
+                    CompletionItem completionItem( void ) const;
+
+                    void completionItem( const CompletionItem& completionItem );
+
+                    static void validate( const Data& data );
+                };
+
+                class CompletionItem : public Data
+                {
+                  public:
+                    CompletionItem( const Data& data );
+
+                    CompletionItem( void );
+
+                    u1 hasSnippetSupport( void ) const;
+
+                    u1 snippetSupport( void ) const;
+
+                    void setSnippetSupport( const u1 snippetSupport );
+
+                    static void validate( const Data& data );
+                };
+            };
+
+            class ClientCapabilities : public Data
+            {
+              public:
+                ClientCapabilities( const Data& data );
+
+                ClientCapabilities( void );
+
+                u1 hasWorkspace( void ) const;
+
+                WorkspaceClientCapabilities workspace( void ) const;
+
+                void setWorkspace( const WorkspaceClientCapabilities& workspace );
+
+                u1 hasTextDocument( void ) const;
+
+                TextDocumentClientCapabilities textDocument( void ) const;
+
+                void setTextDocument( const TextDocumentClientCapabilities& textDocument );
+
+                u1 hasExperimental( void ) const;
+
+                Data experimental( void ) const;
+
+                void setExperimental( const Data& experimental );
+
+                static void validate( const Data& data );
+            };
+
+            class SaveOptions : public Data
+            {
+              public:
+                SaveOptions( const Data& data );
+
+                SaveOptions( void );
+
+                u1 hasIncludeText( void ) const;
+
+                u1 includeText( void ) const;
+
+                void setIncludeText( const u1 includeText );
+
+                static void validate( const Data& data );
+            };
+
+            enum class TextDocumentSyncKind
+            {
+                None = 0,
+                Full = 1,
+                Incremental = 2,
+            };
+
+            class TextDocumentSyncOptions : public Data
+            {
+              public:
+                TextDocumentSyncOptions( const Data& data );
+
+                TextDocumentSyncOptions( void );
+
+                u1 hasOpenClose( void ) const;
+
+                u1 openClose( void ) const;
+
+                void setOpenClose( const u1 openClose );
+
+                u1 hasChange( void ) const;
+
+                TextDocumentSyncKind change( void ) const;
+
+                void setChange( const TextDocumentSyncKind& change );
+
+                u1 hasWillSave( void ) const;
+
+                u1 willSave( void ) const;
+
+                void setWillSave( const u1 willSave );
+
+                u1 hasWillSaveWaitUntil( void ) const;
+
+                u1 willSaveWaitUntil( void ) const;
+
+                void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
+
+                u1 hasSave( void ) const;
+
+                SaveOptions save( void ) const;
+
+                void setSave( const SaveOptions& save );
+
+                static void validate( const Data& data );
+            };
+
+            class CompletionOptions : public Data
+            {
+              public:
+                CompletionOptions( const Data& data );
+
+                CompletionOptions( void );
+
+                u1 hasResolveProvider( void ) const;
+
+                u1 resolveProvider( void ) const;
+
+                void setResolveProvider( const u1 resolveProvider );
+
+                u1 hasTriggerCharacters( void ) const;
+
+                Data triggerCharacters( void ) const;
+
+                void addTriggerCharacters( const std::string& triggerCharacter );
+
+                static void validate( const Data& data );
+            };
+
+            class SignatureHelpOptions : public Data
+            {
+              public:
+                SignatureHelpOptions( const Data& data );
+
+                SignatureHelpOptions( void );
+
+                u1 hasTriggerCharacters( void ) const;
+
+                Data triggerCharacters( void ) const;
+
+                void addTriggerCharacters( const std::string& triggerCharacter );
+
+                static void validate( const Data& data );
+            };
+
+            class CodeLensOptions : public Data
+            {
+              public:
+                CodeLensOptions( const Data& data );
+
+                CodeLensOptions( void );
+
+                u1 hasResolveProvider( void ) const;
+
+                u1 resolveProvider( void ) const;
+
+                void setResolveProvider( const u1 resolveProvider );
+
+                static void validate( const Data& data );
+            };
+
+            class DocumentOnTypeFormattingOptions : public Data
+            {
+              public:
+                DocumentOnTypeFormattingOptions( const Data& data );
+
+                DocumentOnTypeFormattingOptions( const std::string& firstTriggerCharacter );
+
+                std::string firstTriggerCharacter( void ) const;
+
+                u1 hasMoreTriggerCharacter( void ) const;
+
+                Data moreTriggerCharacter( void ) const;
+
+                void addMoreTriggerCharacter( const Data& moreTriggerCharacter );
+
+                static void validate( const Data& data );
+            };
+
+            class RenameOptions : public Data
+            {
+              public:
+                RenameOptions( const Data& data );
+
+                u1 hasPrepareProvider( void ) const;
+
+                u1 prepareProvider( void ) const;
+
+                void setPrepareProvider( const u1 prepareProvider );
+
+                static void validate( const Data& data );
+            };
+
+            using DocumentLinkOptions = CodeLensOptions;
+
+            class ExecuteCommandOptions : public Data
+            {
+              public:
+                ExecuteCommandOptions( const Data& data );
+
+                ExecuteCommandOptions( void );
+
+                u1 hasCommands( void ) const;
+
+                Data commands( void ) const;
+
+                void addCommand( const std::string& command );
+
+                static void validate( const Data& data );
+            };
+            class StaticRegistrationOptions : public Data
+            {
+              public:
+                StaticRegistrationOptions( const Data& data );
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentRegistrationOptions : public Data
+            {
+              public:
+                TextDocumentRegistrationOptions( const Data& data );
+
+                TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
+
+                DocumentSelector documentSelector( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TypeDefinitionProvider : public Data
+            {
+              public:
+                TypeDefinitionProvider( const Data& data );
+
+                DocumentSelector documentSelector( void ) const;
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
+
+            using ImplementationProvider = TypeDefinitionProvider;
+
+            class ColorProviderOptions : public Data
+            {
+              public:
+                ColorProviderOptions( const Data& data );
+
+                static void validate( const Data& data );
+            };
+
+            using FoldingRangeProviderOptions = ColorProviderOptions;
+
+            class ColorProvider : public Data
+            {
+              public:
+                ColorProvider( const Data& data );
+
+                DocumentSelector documentSelector( void ) const;
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
+
+            using FoldingRangeProvider = ColorProvider;
+
+            class Workspace : public Data
+            {
+              public:
+                Workspace( const Data& data );
+
+                static void validate( const Data& data );
+
+                class WorkspaceFolders : public Data
+                {
+                  public:
+                    WorkspaceFolders( const Data& data );
+
+                    u1 supported( void ) const;
+
+                    u1 hasSupported( void ) const;
+
+                    void setSupported( const u1 supported );
+
+                    void setChangeNotifications( const std::string& changeNotifications );
+
+                    void setChangeNotifications( const u1 changeNotifications );
+
+                    u1 hasChangeNotifications( void ) const;
+
+                    std::string changeNotifications( void ) const;
+
+                    static void validate( const Data& data );
+                };
+                WorkspaceFolders workspaceFolders( void ) const;
+
+                u1 hasWorkspaceFolders( void ) const;
+
+                void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
+            };
+            class ServerCapabilities : public Data
+            {
+              public:
+                ServerCapabilities( const Data& data );
+
+                ServerCapabilities( void );
+
+                u1 hasTextDocumentSync( void ) const;
+
+                TextDocumentSyncOptions textDocumentSync( void ) const;
+
+                void setTextDocumentSync( const TextDocumentSyncOptions& textDocumentSync );
+
+                void setTextDocumentSync( const TextDocumentSyncKind& textDocumentSync );
+
+                u1 hasHoverProvider( void ) const;
+
+                u1 hoverProvider( void ) const;
+
+                void setHoverProvider( const u1 hoverProvider );
+
+                u1 hasCompletionProvider( void ) const;
+
+                CompletionOptions completionProvider( void ) const;
+
+                void setCompletionProvider( const CompletionOptions& completionProvider );
+
+                u1 hasSignatureHelpProvider( void ) const;
+
+                SignatureHelpOptions signatureHelpProvider( void ) const;
+
+                void setSignatureHelpProvider( const SignatureHelpOptions& signatureHelpProvider );
+
+                u1 hasDefinitionProvider( void ) const;
+
+                u1 definitionProvider( void ) const;
+
+                void setDefinitionProvider( const u1 definitionProvider );
+
+                u1 hasTypeDefinitionProvider( void ) const;
+
+                TypeDefinitionProvider typeDefinitionProvider( void ) const;
+
+                void setTypeDefinitionProvider(
+                    const TypeDefinitionProvider& typeDefinitionProvider );
+
+                u1 hasImplementationProvider( void ) const;
+
+                ImplementationProvider implementationProvider( void ) const;
+
+                void setImplementationProvider(
+                    const ImplementationProvider& implementationProvider );
+
+                u1 hasReferencesProvider( void ) const;
+
+                u1 referencesProvider( void ) const;
+
+                void setReferencesProvider( const u1 referencesProvider );
+
+                u1 hasDocumentHighlightProvider( void ) const;
+
+                u1 documentHighlightProvider( void ) const;
+
+                void setDocumentHighlightProvider( const u1 documentHighlightProvider );
+
+                u1 hasDocumentSymbolProvider( void ) const;
+
+                u1 documentSymbolProvider( void ) const;
+
+                void setDocumentSymbolProvider( const u1 documentSymbolProvider );
+
+                u1 hasWorkspaceSymbolProvider( void ) const;
+
+                u1 workspaceSymbolProvider( void ) const;
+
+                void setWorkspaceSymbolProvider( const u1 workspaceSymbolProvider );
+
+                u1 hasCodeActionProvider( void ) const;
+
+                u1 codeActionProvider( void ) const;
+
+                void setCodeActionProvider( const u1 codeActionProvider );
+
+                u1 hasCodeLensProvider( void ) const;
+
+                CodeLensOptions codeLensProvider( void ) const;
+
+                void setCodeLensProvider( const CodeLensOptions& codeLensProvider );
+
+                u1 hasDocumentFormattingProvider( void ) const;
+
+                u1 documentFormattingProvider( void ) const;
+
+                void setDocumentFormattingProvider( const u1 documentFormattingProvider );
+
+                u1 hasDocumentRangeFormattingProvider( void ) const;
+
+                u1 documentRangeFormattingProvider( void ) const;
+
+                void setDocumentRangeFormattingProvider( const u1 documentRangeFormattingProvider );
+
+                u1 hasDocumentOnTypeFormattingProvider( void ) const;
+
+                DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider( void ) const;
+
+                void setDocumentOnTypeFormattingProvider(
+                    const DocumentOnTypeFormattingOptions& documentOnTypeFormattingProvider );
+
+                u1 hasRenameProvider( void ) const;
+
+                u1 renameProvider( void ) const;
+
+                void setRenameProvider( const u1 renameProvider );
+
+                u1 hasDocumentLinkProvider( void ) const;
+
+                DocumentLinkOptions documentLinkProvider( void ) const;
+
+                void setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider );
+
+                u1 hasColorProvider( void ) const;
+
+                ColorProvider colorProvider( void ) const;
+
+                void setColorProvider( const ColorProvider& colorProvider );
+
+                u1 hasFoldingRangeProvider( void ) const;
+
+                FoldingRangeProvider foldingRangeProvider( void ) const;
+
+                void setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider );
+
+                u1 hasExecuteCommandProvider( void ) const;
+
+                ExecuteCommandOptions executeCommandProvider( void ) const;
+
+                void setExecuteCommandProvider(
+                    const ExecuteCommandOptions& executeCommandProvider );
+
+                u1 hasExperimental( void ) const;
+
+                Data experimental( void ) const;
+
+                void setExperimental( const Data& experimental );
+
+                u1 hasWorkspace( void ) const;
+
+                void setWorkspace( const Workspace& workspace );
+
+                Workspace workspace( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class WorkspaceFolder : public Data
+            {
+              public:
+                WorkspaceFolder( const std::string& uri, const std::string& name );
+
+                WorkspaceFolder( const Data& data );
+
+                std::string uri( void ) const;
+
+                std::string name( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using WorkspaceFolders = std::vector< WorkspaceFolder >;
+
+            class InitializeParams : public Data
+            {
+              public:
+                InitializeParams( const Data& data );
+
+                InitializeParams(
+                    const std::size_t processId,
+                    const DocumentUri& rootUri,
+                    const ClientCapabilities& capabilities );
+
+                std::size_t processId( void ) const;
+
+                // rootPath interface omitted!
+
+                DocumentUri rootUri( void ) const;
+
+                u1 hasInitializationOptions( void ) const;
+
+                Data initializationOptions( void ) const;
+
+                void setInitializationOptions( const Data& initializationOptions );
+
+                ClientCapabilities capabilities( void ) const;
+
+                u1 hasTrace( void ) const;
+
+                std::string trace( void ) const;
+
+                void setTrace( const std::string& trace );
+
+                WorkspaceFolders workspaceFolders( void ) const;
+
+                u1 hasWorkspaceFolders( void ) const;
+
+                void addWorkspaceFolder( WorkspaceFolder folder );
+
+                static void validate( const Data& data );
+            };
+
+            class InitializeResult : public Data
+            {
+              public:
+                InitializeResult( const Data& data );
+
+                InitializeResult( const ServerCapabilities& capabilities );
+
+                ServerCapabilities capabilities( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class InitializeError : public Data
+            {
+              public:
+                InitializeError( const Data& data );
+
+                InitializeError( const u1 retry );
+
+                u1 retry( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class MessageType
+            {
+                Error = 1,
+
+                Warning = 2,
+
+                Info = 3,
+
+                Log = 4
+            };
+
+            class CancelParams : public Data
+            {
+              public:
+                CancelParams( const Data& data );
+
+                CancelParams( const std::size_t& id );
+
+                CancelParams( const std::string& id );
+
+                std::string id( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class ShowMessageParams : public Data
+            {
+              public:
+                ShowMessageParams( const Data& data );
+
+                ShowMessageParams( const MessageType type, const std::string& message );
+
+                MessageType messageType( void ) const;
+
+                std::string message( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class MessageActionItem : public Data
+            {
+              public:
+                MessageActionItem( const Data& data );
+
+                MessageActionItem( const std::string& title );
+
+                std::string title( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class ShowMessageRequestResult : public Data
+            {
+              public:
+                ShowMessageRequestResult( void );
+
+                ShowMessageRequestResult( const Data& data );
+
+                ShowMessageRequestResult( const MessageActionItem& item );
+
+                ShowMessageRequestResult( const std::string& title );
+
+                static void validate( const Data& data );
+            };
+
+            using MessageActionItems = std::vector< MessageActionItem >;
+
+            class ShowMessageRequestParams : public Data
+            {
+              public:
+                ShowMessageRequestParams( const Data& data );
+
+                ShowMessageRequestParams( const MessageType type, const std::string& message );
+
+                MessageType messageType( void ) const;
+
+                u1 hasActions( void );
+
+                MessageActionItems actions( void ) const;
+
+                void addAction( const MessageActionItem& action );
+
+                std::string message( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using LogMessageParams = ShowMessageParams;
+
+            class TelemetryEventParams : public Data
+            {
+              public:
+                TelemetryEventParams( const Data& data );
+
+                static void validate( const Data& data );
+            };
+
+            class Registration : public Data
+            {
+              public:
+                Registration( const Data& data );
+
+                Registration( const std::string& id, const std::string& method );
+
+                std::string id( void ) const;
+
+                std::string method( void ) const;
+
+                Data registerOptions( void ) const;
+
+                u1 hasRegisterOptions( void ) const;
+
+                void addRegisterOption( const Data& option );
+
+                static void validate( const Data& data );
+            };
+
+            using Registrations = std::vector< Registration >;
+
+            class RegistrationParams : public Data
+            {
+              public:
+                RegistrationParams( const Data& data );
+
+                RegistrationParams( const Registrations& registrations );
+
+                Registrations registrations( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentChangeRegistrationOptions : public TextDocumentRegistrationOptions
+            {
+              public:
+                TextDocumentChangeRegistrationOptions( const Data& data );
+
+                TextDocumentChangeRegistrationOptions(
+                    const DocumentSelector& documentSelector, TextDocumentSyncKind kind );
+
+                TextDocumentSyncKind kind( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentSaveRegistrationOptions : public TextDocumentRegistrationOptions
+            {
+              public:
+                TextDocumentSaveRegistrationOptions( const Data& data );
+
+                TextDocumentSaveRegistrationOptions( const DocumentSelector& documentSelector );
+
+                u1 hasIncludeText( void ) const;
+
+                void setIncludeText( const u1 includeText );
+
+                u1 includeText( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using TriggerCharacters = std::vector< std::string >;
+
+            class SignatureHelpRegistrationOptions : public TextDocumentRegistrationOptions
+            {
+              public:
+                SignatureHelpRegistrationOptions( const Data& data );
+
+                SignatureHelpRegistrationOptions( const DocumentSelector& documentSelector );
+
+                u1 hasTriggerCharacters( void ) const;
+
+                void setTriggerCharacters( const TriggerCharacters& triggerCharacters );
+
+                void addTriggerCharacter( const std::string& triggerCharacter );
+
+                TriggerCharacters triggerCharacters( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class Unregistration : public Data
+            {
+              public:
+                Unregistration( const Data& data );
+
+                Unregistration( const std::string& id, const std::string& method );
+
+                std::string id( void ) const;
+
+                std::string method( void ) const;
+
+                static void validate( const Data& data );
+            };
+            using Unregistrations = std::vector< Unregistration >;
+
+            class UnregistrationParams : public Data
+            {
+              public:
+                UnregistrationParams( const std::vector< Unregistration >& unregistrations );
+
+                UnregistrationParams( const Data& data );
+
+                Unregistrations unregistrations( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class WorkspaceFoldersResult : public Data
+            {
+              public:
+                WorkspaceFoldersResult();
+
+                WorkspaceFoldersResult( const Data& data );
+
+                WorkspaceFoldersResult( const WorkspaceFolders& workspaceFolders );
+
+                WorkspaceFolders toVec( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class WorkspaceFoldersChangeEvent : public Data
+            {
+              public:
+                WorkspaceFoldersChangeEvent(
+                    const WorkspaceFolders& added, const WorkspaceFolders& removed );
+
+                WorkspaceFoldersChangeEvent( const Data& data );
+
+                WorkspaceFolders added( void ) const;
+
+                WorkspaceFolders removed( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class DidChangeWorkspaceFoldersParams : public Data
+            {
+              public:
+                DidChangeWorkspaceFoldersParams( const Data& data );
+
+                DidChangeWorkspaceFoldersParams( const WorkspaceFoldersChangeEvent& event );
+
+                WorkspaceFoldersChangeEvent event( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using DidChangeConfigurationSettings = Data;
+
+            class DidChangeConfigurationParams : public Data
+            {
+              public:
+                DidChangeConfigurationParams( const DidChangeConfigurationSettings& settings );
+
+                DidChangeConfigurationSettings settings( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class ConfigurationItem : public Data
+            {
+              public:
+                ConfigurationItem( const Data& data );
+
+                ConfigurationItem( const std::string& scopeUri, const std::string& section );
+
+                u1 hasScopeUri( void ) const;
+
+                u1 hasSection( void ) const;
+
+                std::string scopeUri( void ) const;
+
+                std::string section( void ) const;
+
+                void setSection( const std::string& section );
+
+                void setScopeUri( const std::string& uri );
+
+                static void validate( const Data& data );
+            };
+
+            class ConfigurationResult : public Data
+            {
+              public:
+                ConfigurationResult( void );
+
+                ConfigurationResult( const Data& data );
+
+                static void validate( const Data& data );
+            };
+
+            using ConfigurationItems = std::vector< ConfigurationItem >;
+
+            class ConfigurationParams : public Data
+            {
+              public:
+                ConfigurationParams( const ConfigurationItems& items );
+
+                ConfigurationParams( const Data& data );
+
+                ConfigurationItems items( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class FileChangeType
+            {
+                Created = 1,
+
+                Changed = 2,
+
+                Deleted = 3
+            };
+
+            /**
+              An event describing a file change.
+             */
+            class FileEvent : public Data
+            {
+              public:
+                FileEvent( const Data& data );
+
+                FileEvent( const DocumentUri& uri, const FileChangeType type );
+
+                DocumentUri documentUri( void ) const;
+
+                FileChangeType type( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using FileEvents = std::vector< FileEvent >;
+
+            class DidChangeWatchedFilesParams : public Data
+            {
+              public:
+                DidChangeWatchedFilesParams( const FileEvents& changes );
+
+                DidChangeWatchedFilesParams( const Data& data );
+
+                FileEvents changes( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class WatchKind
+            {
+
+                Create = 1,
+
+                Change = 2,
+
+                Delete = 4
+            };
+
+            class FileSystemWatcher : public Data
+            {
+              public:
+                FileSystemWatcher( const Data& data );
+
+                FileSystemWatcher( const std::string& globPattern );
+
+                FileSystemWatcher( const std::string& globPattern, const WatchKind kind );
+
+                std::string globPattern( void );
+
+                u1 hasKind( void ) const;
+
+                WatchKind kind( void ) const;
+
+                static void validate( const Data& data );
+
+                void setKind( const WatchKind kind );
+            };
+
+            /**
+              Describe options to be used when registering for text document change events.
+             */
+            using FileSystemWatchers = std::vector< FileSystemWatcher >;
+            class DidChangeWatchedFilesRegistrationOptions : public Data
+            {
+              public:
+                DidChangeWatchedFilesRegistrationOptions( const FileSystemWatchers& watchers );
+
+                DidChangeWatchedFilesRegistrationOptions( const Data& data );
+
+                FileSystemWatchers watchers( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class WorkspaceSymbolParams : public Data
+            {
+              public:
+                WorkspaceSymbolParams( const Data& data );
+
+                WorkspaceSymbolParams( const std::string& query );
+
+                std::string query( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class SymbolKind
+            {
+                File = 1,
+                Module = 2,
+                Namespace = 3,
+                Package = 4,
+                Class = 5,
+                Method = 6,
+                Property = 7,
+                Field = 8,
+                Constructor = 9,
+                Enum = 10,
+                Interface = 11,
+                Function = 12,
+                Variable = 13,
+                Constant = 14,
+                String = 15,
+                Number = 16,
+                Boolean = 17,
+                Array = 18,
+                Object = 19,
+                Key = 20,
+                Null = 21,
+                EnumMember = 22,
+                Struct = 23,
+                Event = 24,
+                Operator = 25,
+                TypeParameter = 26
+            };
+
+            class SymbolInformation : public Data
+            {
+              public:
+                SymbolInformation(
+                    const std::string& name, const SymbolKind kind, const Location& location );
+
+                SymbolInformation( const Data& data );
+
+                u1 isDeprecated( void ) const;
+
+                u1 hasDeprecated( void ) const;
+
+                void setDeprecated( const u1 deprecated );
+
+                std::string containerName( void ) const;
+
+                u1 hasContainerName( void ) const;
+
+                void setContainerName( const std::string& containerName );
+
+                Location location( void ) const;
+
+                std::string name( void ) const;
+
+                SymbolKind kind( void ) const;
+
+                static void validate( const Data& data );
+            };
+            using SymbolInformations = std::vector< SymbolInformation >;
+            class WorkspaceSymbolResult : public Data
+            {
+              public:
+                WorkspaceSymbolResult( const Data& data );
+
+                WorkspaceSymbolResult( const std::vector< SymbolInformation >& symbolInformation );
+
+                void addSymbolInformation( const SymbolInformation& information );
+
+                SymbolInformations symbolInformation( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class ApplyWorkspaceEditParams : public Data
+            {
+              public:
+                ApplyWorkspaceEditParams( const Data& data );
+
+                ApplyWorkspaceEditParams( const WorkspaceEdit& edit );
+
+                WorkspaceEdit edit( void ) const;
+
+                u1 hasLabel( void ) const;
+
+                std::string label( void ) const;
+
+                void setLabel( const std::string& label );
+
+                static void validate( const Data& data );
+            };
+
+            class ApplyWorkspaceEditResult : public Data
+            {
+              public:
+                ApplyWorkspaceEditResult( const Data& data );
+
+                ApplyWorkspaceEditResult( const u1 applied );
+
+                u1 applied( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class DidOpenTextDocumentParams : public Data
+            {
+              public:
+                DidOpenTextDocumentParams( const Data& data );
+
+                DidOpenTextDocumentParams( const TextDocumentItem& textDocument );
+
+                TextDocumentItem textDocument( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentContentChangeEvent : public Data
+            {
+              public:
+                TextDocumentContentChangeEvent( const Data& data );
+
+                TextDocumentContentChangeEvent( const std::string& text );
+
+                u1 hasRange( void ) const;
+
+                Range range( void ) const;
+
+                void setRange( const Range& range );
+
+                u1 hasRangeLength( void ) const;
+
+                std::size_t rangeLength( void ) const;
+
+                void setRangeLength( const std::size_t rangeLength );
+
+                std::string text( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using TextDocumentContentChangeEvents = std::vector< TextDocumentContentChangeEvent >;
+
+            class DidChangeTextDocumentParams : public Data
+            {
+              public:
+                DidChangeTextDocumentParams( const Data& data );
+
+                DidChangeTextDocumentParams(
+                    const VersionedTextDocumentIdentifier& textDocument,
+                    const TextDocumentContentChangeEvents& contentChanges );
+
+                VersionedTextDocumentIdentifier textDocument( void ) const;
+
+                TextDocumentContentChangeEvents contentChanges( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class TextDocumentSaveReason
+            {
+                Manual = 1,  // by the user pressing save, by starting debugging, or by an API call.
+                AfterDelay = 2,  // Automatic after a delay.
+                FocusOut = 3     //  When the editor lost focus.
+            };
+
+            class WillSaveTextDocumentParams : public Data
+            {
+              public:
+                WillSaveTextDocumentParams( const Data& data );
+
+                WillSaveTextDocumentParams(
+                    const TextDocumentIdentifier& textDocument, TextDocumentSaveReason reason );
+
+                TextDocumentSaveReason reason( void ) const;
+
+                TextDocumentIdentifier textDocument( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using TextEdits = std::vector< TextEdit >;
+
+            class WillSaveWaitUntilResponse : public Data
+            {
+              public:
+                WillSaveWaitUntilResponse( const Data& data );
+
+                WillSaveWaitUntilResponse( const std::vector< TextEdit >& textEdit );
+
+                TextEdits textEdit( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class DidSaveTextDocumentParams : public Data
+            {
+              public:
+                DidSaveTextDocumentParams( const Data& data );
+
+                DidSaveTextDocumentParams( const TextDocumentIdentifier& textDocument );
+
+                u1 hasText( void ) const;
+
+                void setText( const std::string& text );
+
+                TextDocumentIdentifier textDocument( void ) const;
+
+                std::string text( void ) const;
+
+                static void validate( const Data& data );
+            };
+            class DidCloseTextDocumentParams : public Data
+            {
+              public:
+                DidCloseTextDocumentParams( const TextDocumentIdentifier& textDocument );
+
+                DidCloseTextDocumentParams( const Data& data );
+
+                TextDocumentIdentifier textDocument( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class CompletionRegistrationOptions : public TextDocumentRegistrationOptions
+            {
+              public:
+                CompletionRegistrationOptions( const Data& data );
+
+                CompletionRegistrationOptions( const DocumentSelector& documentSelector );
+
+                u1 hasTriggerCharacters( void ) const;
+
+                TriggerCharacters triggerCharacters( void ) const;
+
+                void addTriggerCharacter( const std::string& triggerCharacter );
+
+                u1 hasResolveProvider( void ) const;
+
+                u1 resolveProvider( void ) const;
+
+                void setResolveProvider( const u1 resolveProvider );
+
+                static void validate( const Data& data );
+            };
+
+            enum class CompletionTriggerKind
+            {
+                /**
+                 * Completion was triggered by typing an identifier (24x7 code
+                 * complete), manual invocation (e.g Ctrl+Space) or via API.
+                 */
+                Invoked = 1,
+
+                /**
+                 * Completion was triggered by a trigger character specified by
+                 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+                 */
+                TriggerCharacter = 2,
+
+                /**
+                 * Completion was re-triggered as the current completion list is incomplete.
+                 */
+                TriggerForIncompleteCompletions = 3
+            };
+
+            class CompletionContext : public Data
+            {
+              public:
+                CompletionContext( const Data& data );
+
+                CompletionContext( const CompletionTriggerKind triggerkind );
+
+                std::string triggerCharacter( void ) const;
+
+                void setTriggerCharacter( const std::string& triggerCharacter );
+
+                u1 hasTriggerCharacter( void ) const;
+
+                CompletionTriggerKind triggerKind( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class CompletionParams : public TextDocumentPositionParams
+            {
+              public:
+                CompletionParams( const Data& data );
+
+                CompletionParams(
+                    const TextDocumentIdentifier& textDocument, const Position& position );
+
+                CompletionContext context( void ) const;
+
+                u1 hasContext( void ) const;
+
+                void setContext( const CompletionContext& context );
+
+                static void validate( const Data& data );
+            };
+
+            enum class MarkupKind
+            {
+                PLAINTEXT,
+                MARKDOWN
+            };
+
+            class MarkupContent : public Data
+            {
+              public:
+                MarkupContent( const Data& data );
+
+                MarkupContent( const std::string& value );  // kind will be plaintext
+
+                MarkupContent( const MarkupKind kind, const std::string& value );
+
+                std::string kind( void ) const;
+
+                std::string value( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            enum class InsertTextFormat
+            {
+                PlainText = 1,
+                Snippet = 2
+            };
+
+            enum class CompletionItemKind
+            {
+                Text = 1,
+                Method = 2,
+                Function = 3,
+                Constructor = 4,
+                Field = 5,
+                Variable = 6,
+                Class = 7,
+                Interface = 8,
+                Module = 9,
+                Property = 10,
+                Unit = 11,
+                Value = 12,
+                Enum = 13,
+                Keyword = 14,
+                Snippet = 15,
+                Color = 16,
+                File = 17,
+                Reference = 18,
+                Folder = 19,
+                EnumMember = 20,
+                Constant = 21,
+                Struct = 22,
+                Event = 23,
+                Operator = 24,
+                TypeParameter = 25
+            };
+
+            using CommitCharacters = std::vector< std::string >;
 
             class CompletionItem : public Data
             {
               public:
                 CompletionItem( const Data& data );
 
-                CompletionItem( void );
+                CompletionItem( const std::string& label );
 
-                u1 hasSnippetSupport( void ) const;
+                std::string label( void ) const;
 
-                u1 snippetSupport( void ) const;
+                u1 hasKind( void ) const;
 
-                void setSnippetSupport( const u1 snippetSupport );
+                void setKind( const CompletionItemKind kind );
+
+                CompletionItemKind kind( void ) const;
+
+                u1 hasDetail( void ) const;
+
+                void setDetail( const std::string& detail );
+
+                std::string detail( void ) const;
+
+                u1 hasDocumentation( void ) const;
+
+                void setDocumentation( const MarkupContent& doc );
+
+                MarkupContent documentation( void ) const;
+
+                u1 hasDeprecated( void ) const;
+
+                void setDeprecated( const u1 deprecated );
+
+                u1 isDeprecated( void ) const;
+
+                u1 hasPreselected( void ) const;
+
+                void setPreselected( const u1 preselected );
+
+                u1 isPreselected( void ) const;
+
+                u1 hasSortText( void ) const;
+
+                void setSortText( const std::string& sortText );
+
+                std::string sortText( void ) const;
+
+                u1 hasFilterText( void ) const;
+
+                void setFilterText( const std::string& filterText );
+
+                std::string filterText( void ) const;
+
+                u1 hasInsertText( void ) const;
+
+                void setInsertText( const std::string& insertText );
+
+                std::string insertText( void ) const;
+
+                u1 hasInsertTextFormat( void ) const;
+
+                void setInsertTextFormat( const InsertTextFormat insertTextFormat );
+
+                InsertTextFormat insertTextFormat( void ) const;
+
+                u1 hasTextEdit( void ) const;
+
+                void setTextEdit( const TextEdit& textEdit );
+
+                TextEdit textEdit( void ) const;
+
+                u1 hasAdditionalTextEdits( void ) const;
+
+                void addAdditionalTextEdit( const TextEdit& textEdit );
+
+                TextEdits additionalTextEdits( void ) const;
+
+                u1 hasCommitCharacters( void ) const;
+
+                void addCommitCharacter( const std::string& commitCharacter );
+
+                CommitCharacters commitCharacters( void ) const;
+
+                u1 hasCommand( void ) const;
+
+                void setCommand( const Command& command );
+
+                Command command( void ) const;
+
+                u1 hasData( void ) const;
+
+                void setData( const Data& data );
+
+                Data data( void ) const;
 
                 static void validate( const Data& data );
             };
-        };
 
-        class ClientCapabilities : public Data
-        {
-          public:
-            ClientCapabilities( const Data& data );
-
-            ClientCapabilities( void );
-
-            u1 hasWorkspace( void ) const;
-
-            WorkspaceClientCapabilities workspace( void ) const;
-
-            void setWorkspace( const WorkspaceClientCapabilities& workspace );
-
-            u1 hasTextDocument( void ) const;
-
-            TextDocumentClientCapabilities textDocument( void ) const;
-
-            void setTextDocument( const TextDocumentClientCapabilities& textDocument );
-
-            u1 hasExperimental( void ) const;
-
-            Data experimental( void ) const;
-
-            void setExperimental( const Data& experimental );
-
-            static void validate( const Data& data );
-        };
-
-        class SaveOptions : public Data
-        {
-          public:
-            SaveOptions( const Data& data );
-
-            SaveOptions( void );
-
-            u1 hasIncludeText( void ) const;
-
-            u1 includeText( void ) const;
-
-            void setIncludeText( const u1 includeText );
-
-            static void validate( const Data& data );
-        };
-
-        enum class TextDocumentSyncKind
-        {
-            None = 0,
-            Full = 1,
-            Incremental = 2,
-        };
-
-        class TextDocumentSyncOptions : public Data
-        {
-          public:
-            TextDocumentSyncOptions( const Data& data );
-
-            TextDocumentSyncOptions( void );
-
-            u1 hasOpenClose( void ) const;
-
-            u1 openClose( void ) const;
-
-            void setOpenClose( const u1 openClose );
-
-            u1 hasChange( void ) const;
-
-            TextDocumentSyncKind change( void ) const;
-
-            void setChange( const TextDocumentSyncKind& change );
-
-            u1 hasWillSave( void ) const;
-
-            u1 willSave( void ) const;
-
-            void setWillSave( const u1 willSave );
-
-            u1 hasWillSaveWaitUntil( void ) const;
-
-            u1 willSaveWaitUntil( void ) const;
-
-            void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
-
-            u1 hasSave( void ) const;
-
-            SaveOptions save( void ) const;
-
-            void setSave( const SaveOptions& save );
-
-            static void validate( const Data& data );
-        };
-
-        class CompletionOptions : public Data
-        {
-          public:
-            CompletionOptions( const Data& data );
-
-            CompletionOptions( void );
-
-            u1 hasResolveProvider( void ) const;
-
-            u1 resolveProvider( void ) const;
-
-            void setResolveProvider( const u1 resolveProvider );
-
-            u1 hasTriggerCharacters( void ) const;
-
-            Data triggerCharacters( void ) const;
-
-            void addTriggerCharacters( const std::string& triggerCharacter );
-
-            static void validate( const Data& data );
-        };
-
-        class SignatureHelpOptions : public Data
-        {
-          public:
-            SignatureHelpOptions( const Data& data );
-
-            SignatureHelpOptions( void );
-
-            u1 hasTriggerCharacters( void ) const;
-
-            Data triggerCharacters( void ) const;
-
-            void addTriggerCharacters( const std::string& triggerCharacter );
-
-            static void validate( const Data& data );
-        };
-
-        class CodeLensOptions : public Data
-        {
-          public:
-            CodeLensOptions( const Data& data );
-
-            CodeLensOptions( void );
-
-            u1 hasResolveProvider( void ) const;
-
-            u1 resolveProvider( void ) const;
-
-            void setResolveProvider( const u1 resolveProvider );
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentOnTypeFormattingOptions : public Data
-        {
-          public:
-            DocumentOnTypeFormattingOptions( const Data& data );
-
-            DocumentOnTypeFormattingOptions( const std::string& firstTriggerCharacter );
-
-            std::string firstTriggerCharacter( void ) const;
-
-            u1 hasMoreTriggerCharacter( void ) const;
-
-            Data moreTriggerCharacter( void ) const;
-
-            void addMoreTriggerCharacter( const Data& moreTriggerCharacter );
-
-            static void validate( const Data& data );
-        };
-
-        class RenameOptions : public Data
-        {
-          public:
-            RenameOptions( const Data& data );
-
-            u1 hasPrepareProvider( void ) const;
-
-            u1 prepareProvider( void ) const;
-
-            void setPrepareProvider( const u1 prepareProvider );
-
-            static void validate( const Data& data );
-        };
-
-        using DocumentLinkOptions = CodeLensOptions;
-
-        class ExecuteCommandOptions : public Data
-        {
-          public:
-            ExecuteCommandOptions( const Data& data );
-
-            ExecuteCommandOptions( void );
-
-            u1 hasCommands( void ) const;
-
-            Data commands( void ) const;
-
-            void addCommand( const std::string& command );
-
-            static void validate( const Data& data );
-        };
-        class StaticRegistrationOptions : public Data
-        {
-          public:
-            StaticRegistrationOptions( const Data& data );
-
-            u1 hasId( void ) const;
-
-            std::string id( void ) const;
-
-            void setId( std::string id );
-
-            static void validate( const Data& data );
-        };
-
-        class TextDocumentRegistrationOptions : public Data
-        {
-          public:
-            TextDocumentRegistrationOptions( const Data& data );
-
-            TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
-
-            DocumentSelector documentSelector( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class TypeDefinitionProvider : public Data
-        {
-          public:
-            TypeDefinitionProvider( const Data& data );
-
-            DocumentSelector documentSelector( void ) const;
-
-            u1 hasId( void ) const;
-
-            std::string id( void ) const;
-
-            void setId( std::string id );
-
-            static void validate( const Data& data );
-        };
-
-        using ImplementationProvider = TypeDefinitionProvider;
-
-        class ColorProviderOptions : public Data
-        {
-          public:
-            ColorProviderOptions( const Data& data );
-
-            static void validate( const Data& data );
-        };
-
-        using FoldingRangeProviderOptions = ColorProviderOptions;
-
-        class ColorProvider : public Data
-        {
-          public:
-            ColorProvider( const Data& data );
-
-            DocumentSelector documentSelector( void ) const;
-
-            u1 hasId( void ) const;
-
-            std::string id( void ) const;
-
-            void setId( std::string id );
-
-            static void validate( const Data& data );
-        };
-
-        using FoldingRangeProvider = ColorProvider;
-
-        class Workspace : public Data
-        {
-          public:
-            Workspace( const Data& data );
-
-            static void validate( const Data& data );
-
-            class WorkspaceFolders : public Data
+            using CompletionItems = std::vector< CompletionItem >;
+            class CompletionList : public Data
             {
               public:
-                WorkspaceFolders( const Data& data );
+                CompletionList( const Data& data );
 
-                u1 supported( void ) const;
+                CompletionList( const u1 isIncomplete, const CompletionItems& items );
 
-                u1 hasSupported( void ) const;
+                CompletionItems items( void ) const;
 
-                void setSupported( const u1 supported );
-
-                void setChangeNotifications( const std::string& changeNotifications );
-
-                void setChangeNotifications( const u1 changeNotifications );
-
-                u1 hasChangeNotifications( void ) const;
-
-                std::string changeNotifications( void ) const;
+                u1 isIncomplete( void ) const;
 
                 static void validate( const Data& data );
             };
-            WorkspaceFolders workspaceFolders( void ) const;
 
-            u1 hasWorkspaceFolders( void ) const;
+            using CompletionResolveResult = CompletionItem;
 
-            void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
-        };
-        class ServerCapabilities : public Data
-        {
-          public:
-            ServerCapabilities( const Data& data );
+            using SignatureHelpParams = TextDocumentPositionParams;
 
-            ServerCapabilities( void );
+            class CompletionResult : public Data
+            {
+              public:
+                CompletionResult( void );
 
-            u1 hasTextDocumentSync( void ) const;
+                CompletionResult( const Data& data );
 
-            TextDocumentSyncOptions textDocumentSync( void ) const;
+                CompletionResult( const CompletionList& list );
 
-            void setTextDocumentSync( const TextDocumentSyncOptions& textDocumentSync );
+                CompletionResult( const CompletionItems& items );
 
-            void setTextDocumentSync( const TextDocumentSyncKind& textDocumentSync );
+                static void validate( const Data& data );
+            };
 
-            u1 hasHoverProvider( void ) const;
+            class ParameterInformation : public Data
+            {
+              public:
+                ParameterInformation( const Data& data );
 
-            u1 hoverProvider( void ) const;
+                ParameterInformation( const std::string& label );
 
-            void setHoverProvider( const u1 hoverProvider );
+                std::string label( void ) const;
 
-            u1 hasCompletionProvider( void ) const;
+                MarkupContent documentation( void ) const;
 
-            CompletionOptions completionProvider( void ) const;
+                u1 hasDocumentation( void ) const;
 
-            void setCompletionProvider( const CompletionOptions& completionProvider );
+                void setDocumentation( const MarkupContent& doc );
 
-            u1 hasSignatureHelpProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            SignatureHelpOptions signatureHelpProvider( void ) const;
+            using ParameterInformations = std::vector< ParameterInformation >;
+            class SignatureInformation : public Data
+            {
+              public:
+                SignatureInformation( const Data& data );
 
-            void setSignatureHelpProvider( const SignatureHelpOptions& signatureHelpProvider );
+                SignatureInformation( const std::string& label );
 
-            u1 hasDefinitionProvider( void ) const;
+                std::string label( void ) const;
 
-            u1 definitionProvider( void ) const;
+                MarkupContent documentation( void ) const;
 
-            void setDefinitionProvider( const u1 definitionProvider );
+                u1 hasDocumentation( void ) const;
 
-            u1 hasTypeDefinitionProvider( void ) const;
+                void setDocumentation( const MarkupContent& doc );
 
-            TypeDefinitionProvider typeDefinitionProvider( void ) const;
+                u1 hasParameters( void ) const;
 
-            void setTypeDefinitionProvider( const TypeDefinitionProvider& typeDefinitionProvider );
+                ParameterInformations parameters( void ) const;
 
-            u1 hasImplementationProvider( void ) const;
+                void setParameters( const ParameterInformations& parameters );
 
-            ImplementationProvider implementationProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setImplementationProvider( const ImplementationProvider& implementationProvider );
+            using SignatureInformations = std::vector< SignatureInformation >;
+            class SignatureHelp : public Data
+            {
+              public:
+                SignatureHelp( const Data& data );
 
-            u1 hasReferencesProvider( void ) const;
+                SignatureHelp( const SignatureInformations& signatures );
 
-            u1 referencesProvider( void ) const;
+                SignatureInformations signatures( void ) const;
 
-            void setReferencesProvider( const u1 referencesProvider );
+                u1 hasActiveSignature( void ) const;
 
-            u1 hasDocumentHighlightProvider( void ) const;
+                void setActiveSignature( const std::size_t activeSignature );
 
-            u1 documentHighlightProvider( void ) const;
+                std::size_t activeSignature( void ) const;
 
-            void setDocumentHighlightProvider( const u1 documentHighlightProvider );
+                u1 hasActiveParameter( void ) const;
 
-            u1 hasDocumentSymbolProvider( void ) const;
+                void setActiveParameter( const std::size_t activeParameter );
 
-            u1 documentSymbolProvider( void ) const;
+                std::size_t activeParameter( void ) const;
 
-            void setDocumentSymbolProvider( const u1 documentSymbolProvider );
+                static void validate( const Data& data );
+            };
 
-            u1 hasWorkspaceSymbolProvider( void ) const;
+            class SignatureHelpResult : public Data
+            {
+              public:
+                SignatureHelpResult( void );
 
-            u1 workspaceSymbolProvider( void ) const;
+                SignatureHelpResult( const Data& data );
 
-            void setWorkspaceSymbolProvider( const u1 workspaceSymbolProvider );
+                SignatureHelpResult( const SignatureHelp& signature );
 
-            u1 hasCodeActionProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            u1 codeActionProvider( void ) const;
+            using TypeDefinitionParams = TextDocumentPositionParams;
 
-            void setCodeActionProvider( const u1 codeActionProvider );
+            using Locations = std::vector< Location >;
 
-            u1 hasCodeLensProvider( void ) const;
+            class LocationLink : public Data
+            {
+              public:
+                LocationLink( const Data& data );
 
-            CodeLensOptions codeLensProvider( void ) const;
+                LocationLink( const DocumentUri& targetUri, const Range& targetRange );
 
-            void setCodeLensProvider( const CodeLensOptions& codeLensProvider );
+                DocumentUri targetUri( void ) const;
 
-            u1 hasDocumentFormattingProvider( void ) const;
+                Range targetRange( void ) const;
 
-            u1 documentFormattingProvider( void ) const;
+                u1 hasOriginSelectionRange( void ) const;
 
-            void setDocumentFormattingProvider( const u1 documentFormattingProvider );
+                void setOriginSelectionRange( const Range& range );
 
-            u1 hasDocumentRangeFormattingProvider( void ) const;
+                Range originSelectionRange( void ) const;
 
-            u1 documentRangeFormattingProvider( void ) const;
+                u1 hasTargetSelectionRange( void ) const;
 
-            void setDocumentRangeFormattingProvider( const u1 documentRangeFormattingProvider );
+                void setTargetSelectionRange( const Range& range );
 
-            u1 hasDocumentOnTypeFormattingProvider( void ) const;
+                Range targetSelectionRange( void ) const;
 
-            DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setDocumentOnTypeFormattingProvider(
-                const DocumentOnTypeFormattingOptions& documentOnTypeFormattingProvider );
+            using LocationLinks = std::vector< LocationLink >;
 
-            u1 hasRenameProvider( void ) const;
+            class TypeDefinitionResult : public Data
+            {
+              public:
+                TypeDefinitionResult( const Data& data );
 
-            u1 renameProvider( void ) const;
+                TypeDefinitionResult( const Locations& locations );
 
-            void setRenameProvider( const u1 renameProvider );
+                TypeDefinitionResult( const LocationLinks& locationLinks );
 
-            u1 hasDocumentLinkProvider( void ) const;
+                TypeDefinitionResult( const Location& location );
 
-            DocumentLinkOptions documentLinkProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider );
+            using TextDocumentImplementationResult = TypeDefinitionResult;
 
-            u1 hasColorProvider( void ) const;
+            using TextDocumentImplementationParams = TextDocumentPositionParams;
 
-            ColorProvider colorProvider( void ) const;
+            class ReferenceContext : public Data
+            {
+              public:
+                ReferenceContext( const Data& data );
 
-            void setColorProvider( const ColorProvider& colorProvider );
+                ReferenceContext( const u1 includeDeclaration );
 
-            u1 hasFoldingRangeProvider( void ) const;
+                u1 includeDeclaration( void ) const;
 
-            FoldingRangeProvider foldingRangeProvider( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider );
+            class ReferenceParams : public TextDocumentPositionParams
+            {
+              public:
+                ReferenceParams( const Data& data );
 
-            u1 hasExecuteCommandProvider( void ) const;
+                ReferenceParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const Position& position,
+                    const ReferenceContext& context );
 
-            ExecuteCommandOptions executeCommandProvider( void ) const;
+                ReferenceContext context( void ) const;
 
-            void setExecuteCommandProvider( const ExecuteCommandOptions& executeCommandProvider );
+                static void validate( const Data& data );
+            };
+            class ReferenceResult : public Data
+            {
+              public:
+                ReferenceResult( const Data& data );
 
-            u1 hasExperimental( void ) const;
+                ReferenceResult( const Locations& locations );
 
-            Data experimental( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setExperimental( const Data& experimental );
+            enum class CodeActionKind
+            {
+                QuickFix,
+                Refactor,
+                RefactorExtract,
+                RefactorInline,
+                RefactorRewrite,
+                Source,
+                SourceOrganizeImports
+            };
 
-            u1 hasWorkspace( void ) const;
+            class CodeActionOptions : public Data
+            {
+              public:
+                CodeActionOptions( const Data& data );
 
-            void setWorkspace( const Workspace& workspace );
+                u1 hasCodeActionKinds( void ) const;
 
-            Workspace workspace( void ) const;
+                void addCodeActionKind( CodeActionKind kind );
 
-            static void validate( const Data& data );
-        };
+                std::vector< std::string > codeActionKinds( void ) const;
 
-        class WorkspaceFolder : public Data
-        {
-          public:
-            WorkspaceFolder( const std::string& uri, const std::string& name );
+                static void validate( const Data& data );
+            };
 
-            WorkspaceFolder( const Data& data );
+            using Diagnostics = std::vector< Diagnostic >;
 
-            std::string uri( void ) const;
+            class CodeActionContext : public Data
+            {
+              public:
+                CodeActionContext( const Data& data );
 
-            std::string name( void ) const;
+                CodeActionContext( const Diagnostics& diagnostics );
 
-            static void validate( const Data& data );
-        };
+                Diagnostics diagnostics( void ) const;
 
-        using WorkspaceFolders = std::vector< WorkspaceFolder >;
+                u1 hasKind( void ) const;
 
-        class InitializeParams : public Data
-        {
-          public:
-            InitializeParams( const Data& data );
+                void setKind( const CodeActionKind kind );
 
-            InitializeParams(
-                const std::size_t processId,
-                const DocumentUri& rootUri,
-                const ClientCapabilities& capabilities );
+                std::string kind( void ) const;
 
-            std::size_t processId( void ) const;
+                static void validate( const Data& data );
+            };
 
-            // rootPath interface omitted!
+            class CodeActionParams : public Data
+            {
+              public:
+                CodeActionParams( const Data& data );
 
-            DocumentUri rootUri( void ) const;
+                CodeActionParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const Range& range,
+                    const CodeActionContext& context );
 
-            u1 hasInitializationOptions( void ) const;
+                TextDocumentIdentifier textDocument( void ) const;
 
-            Data initializationOptions( void ) const;
+                Range range( void ) const;
 
-            void setInitializationOptions( const Data& initializationOptions );
+                CodeActionContext context( void ) const;
 
-            ClientCapabilities capabilities( void ) const;
+                static void validate( const Data& data );
+            };
 
-            u1 hasTrace( void ) const;
+            class CodeAction : public Data
+            {
+              public:
+                CodeAction( const Data& data );
 
-            std::string trace( void ) const;
+                CodeAction( const std::string& title );
 
-            void setTrace( const std::string& trace );
+                std::string title( void ) const;
 
-            WorkspaceFolders workspaceFolders( void ) const;
+                u1 hasKind( void ) const;
 
-            u1 hasWorkspaceFolders( void ) const;
+                std::string kind( void ) const;
 
-            void addWorkspaceFolder( WorkspaceFolder folder );
+                void setKind( const CodeActionKind kind );
 
-            static void validate( const Data& data );
-        };
+                u1 hasDiagnostics( void ) const;
 
-        class InitializeResult : public Data
-        {
-          public:
-            InitializeResult( const Data& data );
+                Diagnostics diagnostics( void ) const;
 
-            InitializeResult( const ServerCapabilities& capabilities );
+                void addDiagnostic( const Diagnostic& diagnostic );
 
-            ServerCapabilities capabilities( void ) const;
+                u1 hasEdit( void ) const;
 
-            static void validate( const Data& data );
-        };
+                WorkspaceEdit edit( void ) const;
 
-        class InitializeError : public Data
-        {
-          public:
-            InitializeError( const Data& data );
+                void setEdit( const WorkspaceEdit& edit );
 
-            InitializeError( const u1 retry );
+                void setCommand( const Command& command );
 
-            u1 retry( void ) const;
+                u1 hasCommand( void ) const;
 
-            static void validate( const Data& data );
-        };
+                Command command( void ) const;
 
-        enum class MessageType
-        {
-            Error = 1,
+                static void validate( const Data& data );
+            };
 
-            Warning = 2,
+            class CodeActionResult : public Data
+            {
+              public:
+                CodeActionResult( const Data& data );
 
-            Info = 3,
+                CodeActionResult( const std::vector< Command >& commands );
 
-            Log = 4
-        };
+                CodeActionResult( void );
 
-        class CancelParams : public Data
-        {
-          public:
-            CancelParams( const Data& data );
+                void addCommand( const Command& command );
 
-            CancelParams( const std::size_t& id );
+                static void validate( const Data& data );
+            };
 
-            CancelParams( const std::string& id );
+            class CodeActionRegistrationOptions
+            : public TextDocumentRegistrationOptions
+            , public CodeActionOptions
+            {
+            };
 
-            std::string id( void ) const;
+            class PublishDiagnosticsParams : public Data
+            {
+              public:
+                PublishDiagnosticsParams( const Data& data );
 
-            static void validate( const Data& data );
-        };
+                PublishDiagnosticsParams(
+                    const DocumentUri& uri, const std::vector< Diagnostic >& diagnostics );
 
-        class ShowMessageParams : public Data
-        {
-          public:
-            ShowMessageParams( const Data& data );
+                DocumentUri uri( void ) const;
 
-            ShowMessageParams( const MessageType type, const std::string& message );
+                Data diagnostics( void ) const;
 
-            MessageType messageType( void ) const;
+                static void validate( const Data& data );
+            };
 
-            std::string message( void ) const;
+            using HoverParams = TextDocumentPositionParams;
 
-            static void validate( const Data& data );
-        };
+            class MarkedString : public Data
+            {
+              public:
+                MarkedString( const Data& data );
 
-        class MessageActionItem : public Data
-        {
-          public:
-            MessageActionItem( const Data& data );
+                MarkedString( const std::string& language, const std::string& value );
 
-            MessageActionItem( const std::string& title );
+                std::string language( void ) const;
 
-            std::string title( void ) const;
+                std::string value( void ) const;
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        class ShowMessageRequestResult : public Data
-        {
-          public:
-            ShowMessageRequestResult( void );
+            class HoverResult : public Data
+            {
+              public:
+                HoverResult( const Data& data );
 
-            ShowMessageRequestResult( const Data& data );
+                HoverResult( const std::vector< MarkedString >& contents = {} );
 
-            ShowMessageRequestResult( const MessageActionItem& item );
+                Data contents( void ) const;
 
-            ShowMessageRequestResult( const std::string& title );
+                void addContent( const MarkedString& content );
 
-            static void validate( const Data& data );
-        };
+                u1 hasRange( void ) const;
 
-        using MessageActionItems = std::vector< MessageActionItem >;
+                Range range( void ) const;
 
-        class ShowMessageRequestParams : public Data
-        {
-          public:
-            ShowMessageRequestParams( const Data& data );
+                void setRange( const Range& range );
 
-            ShowMessageRequestParams( const MessageType type, const std::string& message );
+                static void validate( const Data& data );
+            };
 
-            MessageType messageType( void ) const;
+            using DefinitionParams = TextDocumentPositionParams;
 
-            u1 hasActions( void );
+            class DefinitionResult : public Data
+            {
+              public:
+                DefinitionResult( const Data& data );
 
-            MessageActionItems actions( void ) const;
+                DefinitionResult( const Location& location );
 
-            void addAction( const MessageActionItem& action );
+                DefinitionResult( const std::vector< Location > locations );
 
-            std::string message( void ) const;
+                Data locations( void ) const;
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        using LogMessageParams = ShowMessageParams;
+            using DocumentHighlightParams = TextDocumentPositionParams;
 
-        class TelemetryEventParams : public Data
-        {
-          public:
-            TelemetryEventParams( const Data& data );
+            enum class DocumentHighlightKind
+            {
+                Text = 1,
+                Read = 2,
+                Write = 3
+            };
 
-            static void validate( const Data& data );
-        };
+            class DocumentHighlight : public Data
+            {
+              public:
+                DocumentHighlight( const Data& data );
 
-        class Registration : public Data
-        {
-          public:
-            Registration( const Data& data );
+                DocumentHighlight( const Range& range );
 
-            Registration( const std::string& id, const std::string& method );
+                Range range( void ) const;
 
-            std::string id( void ) const;
+                u1 hasKind( void ) const;
 
-            std::string method( void ) const;
+                DocumentHighlightKind kind( void ) const;
 
-            Data registerOptions( void ) const;
+                void setKind( const DocumentHighlightKind kind );
 
-            u1 hasRegisterOptions( void ) const;
+                static void validate( const Data& data );
+            };
+            using DocumentHighlights = std::vector< DocumentHighlight >;
 
-            void addRegisterOption( const Data& option );
+            class DocumentHighlightResult : public Data
+            {
+              public:
+                DocumentHighlightResult( void );
 
-            static void validate( const Data& data );
-        };
+                DocumentHighlightResult( const Data& data );
 
-        using Registrations = std::vector< Registration >;
+                DocumentHighlightResult( const DocumentHighlights& highlights );
 
-        class RegistrationParams : public Data
-        {
-          public:
-            RegistrationParams( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            RegistrationParams( const Registrations& registrations );
+            class DocumentSymbolParams : public Data
+            {
+              public:
+                DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
 
-            Registrations registrations( void ) const;
+                DocumentSymbolParams( const Data& data );
 
-            static void validate( const Data& data );
-        };
+                TextDocumentIdentifier textDocument( void ) const;
 
-        class TextDocumentChangeRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            TextDocumentChangeRegistrationOptions( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            TextDocumentChangeRegistrationOptions(
-                const DocumentSelector& documentSelector, TextDocumentSyncKind kind );
+            class DocumentSymbol;
 
-            TextDocumentSyncKind kind( void ) const;
+            using DocumentSymbols = std::vector< DocumentSymbol >;
 
-            static void validate( const Data& data );
-        };
+            class DocumentSymbol : public Data
+            {
+              public:
+                DocumentSymbol( const Data& data );
 
-        class TextDocumentSaveRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            TextDocumentSaveRegistrationOptions( const Data& data );
+                DocumentSymbol(
+                    const std::string& name,
+                    const SymbolKind kind,
+                    Range range,
+                    Range selectionRange );
 
-            TextDocumentSaveRegistrationOptions( const DocumentSelector& documentSelector );
+                std::string name( void ) const;
 
-            u1 hasIncludeText( void ) const;
+                SymbolKind kind( void ) const;
 
-            void setIncludeText( const u1 includeText );
+                Range range( void ) const;
 
-            u1 includeText( void ) const;
+                Range selectionRange( void ) const;
 
-            static void validate( const Data& data );
-        };
+                u1 hasDetail( void ) const;
 
-        using TriggerCharacters = std::vector< std::string >;
+                void setDetail( const std::string& detail );
 
-        class SignatureHelpRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            SignatureHelpRegistrationOptions( const Data& data );
+                std::string detail( void ) const;
 
-            SignatureHelpRegistrationOptions( const DocumentSelector& documentSelector );
+                u1 hasDeprecated( void ) const;
 
-            u1 hasTriggerCharacters( void ) const;
+                u1 deprecated( void ) const;
 
-            void setTriggerCharacters( const TriggerCharacters& triggerCharacters );
+                void setDeprecated( const u1 deprecated );
 
-            void addTriggerCharacter( const std::string& triggerCharacter );
+                u1 hasChildren( void ) const;
 
-            TriggerCharacters triggerCharacters( void ) const;
+                DocumentSymbols children( void ) const;
 
-            static void validate( const Data& data );
-        };
+                void addChild( const DocumentSymbol& symbol );
 
-        class Unregistration : public Data
-        {
-          public:
-            Unregistration( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            Unregistration( const std::string& id, const std::string& method );
+            class DocumentSymbolResult : public Data
+            {
+              public:
+                DocumentSymbolResult( void );
 
-            std::string id( void ) const;
+                DocumentSymbolResult( const Data& data );
 
-            std::string method( void ) const;
+                DocumentSymbolResult( const DocumentSymbols& symbols );
 
-            static void validate( const Data& data );
-        };
-        using Unregistrations = std::vector< Unregistration >;
+                DocumentSymbolResult( const SymbolInformations& information );
 
-        class UnregistrationParams : public Data
-        {
-          public:
-            UnregistrationParams( const std::vector< Unregistration >& unregistrations );
+                static void validate( const Data& data );
+            };
 
-            UnregistrationParams( const Data& data );
+            class CodeLensParams : public Data
+            {
+              public:
+                CodeLensParams( const Data& data );
 
-            Unregistrations unregistrations( void ) const;
+                CodeLensParams( const TextDocumentIdentifier& textDocument );
 
-            static void validate( const Data& data );
-        };
+                TextDocumentIdentifier textDocument( void ) const;
 
-        class WorkspaceFoldersResult : public Data
-        {
-          public:
-            WorkspaceFoldersResult();
+                static void validate( const Data& data );
+            };
 
-            WorkspaceFoldersResult( const Data& data );
+            class CodeLens : public Data
+            {
+              public:
+                CodeLens( const Data& data );
 
-            WorkspaceFoldersResult( const WorkspaceFolders& workspaceFolders );
+                CodeLens( const Range& range );
 
-            WorkspaceFolders toVec( void ) const;
+                Range range( void ) const;
 
-            static void validate( const Data& data );
-        };
+                u1 hasCommand( void ) const;
 
-        class WorkspaceFoldersChangeEvent : public Data
-        {
-          public:
-            WorkspaceFoldersChangeEvent(
-                const WorkspaceFolders& added, const WorkspaceFolders& removed );
+                Command command( void ) const;
 
-            WorkspaceFoldersChangeEvent( const Data& data );
+                void setCommand( const Command& command );
 
-            WorkspaceFolders added( void ) const;
+                u1 hasData( void ) const;
 
-            WorkspaceFolders removed( void ) const;
+                Data data( void ) const;
 
-            static void validate( const Data& data );
-        };
+                void setData( const Data& data );
 
-        class DidChangeWorkspaceFoldersParams : public Data
-        {
-          public:
-            DidChangeWorkspaceFoldersParams( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            DidChangeWorkspaceFoldersParams( const WorkspaceFoldersChangeEvent& event );
+            class CodeLensResult : public Data
+            {
+              public:
+                CodeLensResult( const Data& data );
 
-            WorkspaceFoldersChangeEvent event( void ) const;
+                CodeLensResult( const std::vector< CodeLens >& codeLens = {} );
 
-            static void validate( const Data& data );
-        };
+                void addCodeLens( const CodeLens& codeLens );
 
-        using DidChangeConfigurationSettings = Data;
+                static void validate( const Data& data );
+            };
 
-        class DidChangeConfigurationParams : public Data
-        {
-          public:
-            DidChangeConfigurationParams( const DidChangeConfigurationSettings& settings );
+            class DocumentLinkParams : public Data
+            {
+              public:
+                DocumentLinkParams( const Data& data );
 
-            DidChangeConfigurationSettings settings( void ) const;
+                DocumentLinkParams( const TextDocumentIdentifier& textDocument );
 
-            static void validate( const Data& data );
-        };
+                TextDocumentIdentifier textDocument( void ) const;
 
-        class ConfigurationItem : public Data
-        {
-          public:
-            ConfigurationItem( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            ConfigurationItem( const std::string& scopeUri, const std::string& section );
+            class DocumentLink : public Data
+            {
+              public:
+                DocumentLink( const Data& data );
 
-            u1 hasScopeUri( void ) const;
+                DocumentLink( const Range& range );
 
-            u1 hasSection( void ) const;
+                Range range( void ) const;
 
-            std::string scopeUri( void ) const;
+                u1 hasTarget( void ) const;
 
-            std::string section( void ) const;
+                void setTarget( const DocumentUri& target );
 
-            void setSection( const std::string& section );
+                DocumentUri target( void ) const;
 
-            void setScopeUri( const std::string& uri );
+                u1 hasData( void ) const;
 
-            static void validate( const Data& data );
-        };
+                void setData( const Data& data );
 
-        class ConfigurationResult : public Data
-        {
-          public:
-            ConfigurationResult( void );
+                Data data( void ) const;
 
-            ConfigurationResult( const Data& data );
+                static void validate( const Data& data );
+            };
+            using DocumentLinks = std::vector< DocumentLink >;
+            class DocumentLinkResult : public Data
+            {
+              public:
+                DocumentLinkResult( void );
 
-            static void validate( const Data& data );
-        };
+                DocumentLinkResult( const Data& data );
 
-        using ConfigurationItems = std::vector< ConfigurationItem >;
+                DocumentLinkResult( const DocumentLinks links );
 
-        class ConfigurationParams : public Data
-        {
-          public:
-            ConfigurationParams( const ConfigurationItems& items );
+                static void validate( const Data& data );
+            };
 
-            ConfigurationParams( const Data& data );
+            using CodeLensResolveParams = CodeLens;
+            using CodeLensResolveResult = CodeLens;
+            using DocumentLinkResolveResult = DocumentLink;
+            using DocumentLinkResolveParams = DocumentLink;
 
-            ConfigurationItems items( void ) const;
+            class DocumentColorParams : public Data
+            {
+              public:
+                DocumentColorParams( const Data& data );
 
-            static void validate( const Data& data );
-        };
+                DocumentColorParams( const TextDocumentIdentifier& textDocument );
 
-        enum class FileChangeType
-        {
-            Created = 1,
+                TextDocumentIdentifier textDocument( void ) const;
 
-            Changed = 2,
+                static void validate( const Data& data );
+            };
 
-            Deleted = 3
-        };
+            class Color : public Data
+            {
+              public:
+                Color( const Data& data );
 
-        /**
-          An event describing a file change.
-         */
-        class FileEvent : public Data
-        {
-          public:
-            FileEvent( const Data& data );
+                Color( const float red, const float green, const float blue, const float alpha );
 
-            FileEvent( const DocumentUri& uri, const FileChangeType type );
+                float red( void ) const;
 
-            DocumentUri documentUri( void ) const;
+                float green( void ) const;
 
-            FileChangeType type( void ) const;
+                float blue( void ) const;
 
-            static void validate( const Data& data );
-        };
+                float alpha( void ) const;
 
-        using FileEvents = std::vector< FileEvent >;
+                static void validate( const Data& data );
+            };
 
-        class DidChangeWatchedFilesParams : public Data
-        {
-          public:
-            DidChangeWatchedFilesParams( const FileEvents& changes );
+            class ColorInformation : public Data
+            {
+              public:
+                ColorInformation( const Data& data );
 
-            DidChangeWatchedFilesParams( const Data& data );
+                ColorInformation( const Range& range, const Color& color );
 
-            FileEvents changes( void ) const;
+                Range range( void ) const;
 
-            static void validate( const Data& data );
-        };
+                Color color( void ) const;
 
-        enum class WatchKind
-        {
+                static void validate( const Data& data );
+            };
+            using ColorInformations = std::vector< ColorInformation >;
 
-            Create = 1,
+            class DocumentColorResult : public Data
+            {
+              public:
+                DocumentColorResult( const Data& data );
 
-            Change = 2,
+                DocumentColorResult( const ColorInformations& colorInformations );
 
-            Delete = 4
-        };
+                static void validate( const Data& data );
+            };
 
-        class FileSystemWatcher : public Data
-        {
-          public:
-            FileSystemWatcher( const Data& data );
+            class ColorPresentationParams : public DocumentColorParams
+            {
+              public:
+                ColorPresentationParams( const Data& data );
 
-            FileSystemWatcher( const std::string& globPattern );
+                ColorPresentationParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const Color& color,
+                    const Range& range );
 
-            FileSystemWatcher( const std::string& globPattern, const WatchKind kind );
+                Color color( void ) const;
 
-            std::string globPattern( void );
+                Range range( void ) const;
 
-            u1 hasKind( void ) const;
+                static void validate( const Data& data );
+            };
 
-            WatchKind kind( void ) const;
+            class ColorPresentation : public Data
+            {
+              public:
+                ColorPresentation( const Data& data );
 
-            static void validate( const Data& data );
+                ColorPresentation( const std::string& label );
 
-            void setKind( const WatchKind kind );
-        };
+                std::string label( void ) const;
 
-        /**
-          Describe options to be used when registering for text document change events.
-         */
-        using FileSystemWatchers = std::vector< FileSystemWatcher >;
-        class DidChangeWatchedFilesRegistrationOptions : public Data
-        {
-          public:
-            DidChangeWatchedFilesRegistrationOptions( const FileSystemWatchers& watchers );
+                u1 hasTextEdit( void ) const;
 
-            DidChangeWatchedFilesRegistrationOptions( const Data& data );
+                void setTextEdit( const TextEdit& textEdit );
 
-            FileSystemWatchers watchers( void ) const;
+                TextEdit textEdit( void ) const;
 
-            static void validate( const Data& data );
-        };
+                u1 hasAdditionalTextEdits( void ) const;
 
-        class WorkspaceSymbolParams : public Data
-        {
-          public:
-            WorkspaceSymbolParams( const Data& data );
+                void addAdditionalTextEdit( const TextEdit& textEdit );
 
-            WorkspaceSymbolParams( const std::string& query );
+                TextEdits additionalTextEdits( void ) const;
 
-            std::string query( void ) const;
+                static void validate( const Data& data );
+            };
 
-            static void validate( const Data& data );
-        };
+            using ColorPresentations = std::vector< ColorPresentation >;
 
-        enum class SymbolKind
-        {
-            File = 1,
-            Module = 2,
-            Namespace = 3,
-            Package = 4,
-            Class = 5,
-            Method = 6,
-            Property = 7,
-            Field = 8,
-            Constructor = 9,
-            Enum = 10,
-            Interface = 11,
-            Function = 12,
-            Variable = 13,
-            Constant = 14,
-            String = 15,
-            Number = 16,
-            Boolean = 17,
-            Array = 18,
-            Object = 19,
-            Key = 20,
-            Null = 21,
-            EnumMember = 22,
-            Struct = 23,
-            Event = 24,
-            Operator = 25,
-            TypeParameter = 26
-        };
+            class ColorPresentationResult : public Data
+            {
+              public:
+                ColorPresentationResult( const Data& data );
 
-        class SymbolInformation : public Data
-        {
-          public:
-            SymbolInformation(
-                const std::string& name, const SymbolKind kind, const Location& location );
+                ColorPresentationResult( ColorPresentations presentations );
 
-            SymbolInformation( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            u1 isDeprecated( void ) const;
+            class FormattingOptions : public Data
+            {
+              private:
+                static void validateAdditionalOptions( const Data& data );
 
-            u1 hasDeprecated( void ) const;
+              public:
+                FormattingOptions( const Data& data );
 
-            void setDeprecated( const u1 deprecated );
+                FormattingOptions( const std::size_t tabSize, const u1 insertSpaces );
 
-            std::string containerName( void ) const;
+                std::size_t tabSize( void ) const;
 
-            u1 hasContainerName( void ) const;
+                void addBool( const std::string& key, const u1 boolean );
 
-            void setContainerName( const std::string& containerName );
+                void addNumber( const std::string& key, const float number );
 
-            Location location( void ) const;
+                void addString( const std::string& key, const std::string& string );
 
-            std::string name( void ) const;
+                u1 insertSpaces( void ) const;
 
-            SymbolKind kind( void ) const;
+                static void validate( const Data& data );
+            };
 
-            static void validate( const Data& data );
-        };
-        using SymbolInformations = std::vector< SymbolInformation >;
-        class WorkspaceSymbolResult : public Data
-        {
-          public:
-            WorkspaceSymbolResult( const Data& data );
+            class DocumentFormattingParams : public Data
+            {
+              public:
+                DocumentFormattingParams( const Data& data );
 
-            WorkspaceSymbolResult( const std::vector< SymbolInformation >& symbolInformation );
+                DocumentFormattingParams(
+                    const TextDocumentIdentifier& textDocument, const FormattingOptions& options );
 
-            void addSymbolInformation( const SymbolInformation& information );
+                TextDocumentIdentifier textDocument( void ) const;
 
-            SymbolInformations symbolInformation( void ) const;
+                FormattingOptions options( void ) const;
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        class ApplyWorkspaceEditParams : public Data
-        {
-          public:
-            ApplyWorkspaceEditParams( const Data& data );
+            class DocumentFormattingResult : public Data
+            {
+              public:
+                DocumentFormattingResult( void );
 
-            ApplyWorkspaceEditParams( const WorkspaceEdit& edit );
+                DocumentFormattingResult( const Data& data );
 
-            WorkspaceEdit edit( void ) const;
+                DocumentFormattingResult( const TextEdits& edits );
 
-            u1 hasLabel( void ) const;
+                static void validate( const Data& data );
+            };
+            class DocumentRangeFormattingParams : public DocumentFormattingParams
+            {
+              public:
+                DocumentRangeFormattingParams( const Data& data );
 
-            std::string label( void ) const;
+                DocumentRangeFormattingParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const Range& range,
+                    const FormattingOptions& options );
 
-            void setLabel( const std::string& label );
+                Range range( void ) const;
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        class ApplyWorkspaceEditResult : public Data
-        {
-          public:
-            ApplyWorkspaceEditResult( const Data& data );
+            class DocumentOnTypeFormattingParams : public DocumentFormattingParams
+            {
+              public:
+                DocumentOnTypeFormattingParams( const Data& data );
 
-            ApplyWorkspaceEditResult( const u1 applied );
+                DocumentOnTypeFormattingParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const FormattingOptions& options,
+                    const Position& position,
+                    const std::string& ch );
 
-            u1 applied( void ) const;
+                Position position( void ) const;
 
-            static void validate( const Data& data );
-        };
+                std::string ch( void ) const;  // character that has been typed.
 
-        class DidOpenTextDocumentParams : public Data
-        {
-          public:
-            DidOpenTextDocumentParams( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            DidOpenTextDocumentParams( const TextDocumentItem& textDocument );
+            class DocumentOnTypeFormattingRegistrationOptions
+            : public TextDocumentRegistrationOptions
+            {
+              public:
+                DocumentOnTypeFormattingRegistrationOptions( const Data& data );
 
-            TextDocumentItem textDocument( void ) const;
+                DocumentOnTypeFormattingRegistrationOptions(
+                    const DocumentSelector& documentSelector,
+                    const std::string& firstTriggerCharacter );
 
-            static void validate( const Data& data );
-        };
+                std::string firstTriggerCharacter( void ) const;
 
-        class TextDocumentContentChangeEvent : public Data
-        {
-          public:
-            TextDocumentContentChangeEvent( const Data& data );
+                u1 hasMoreTriggerCharacter( void ) const;
 
-            TextDocumentContentChangeEvent( const std::string& text );
+                void addMoreTriggerCharacter( const std::string& character );
 
-            u1 hasRange( void ) const;
+                std::vector< std::string > moreTriggerCharacter( void ) const;
 
-            Range range( void ) const;
+                static void validate( const Data& data );
+            };
 
-            void setRange( const Range& range );
+            using DocumentOnTypeFormattingResult = DocumentFormattingResult;
 
-            u1 hasRangeLength( void ) const;
+            using DocumentRangeFormattingResult = DocumentFormattingResult;
 
-            std::size_t rangeLength( void ) const;
+            class RenameParams : public Data
+            {
+              public:
+                RenameParams( const Data& data );
 
-            void setRangeLength( const std::size_t rangeLength );
+                RenameParams(
+                    const TextDocumentIdentifier& textDocument,
+                    const Position& position,
+                    const std::string& newName );
 
-            std::string text( void ) const;
+                TextDocumentIdentifier textDocument( void ) const;
 
-            static void validate( const Data& data );
-        };
+                Position position( void ) const;
 
-        using TextDocumentContentChangeEvents = std::vector< TextDocumentContentChangeEvent >;
+                std::string newName( void ) const;
 
-        class DidChangeTextDocumentParams : public Data
-        {
-          public:
-            DidChangeTextDocumentParams( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            DidChangeTextDocumentParams(
-                const VersionedTextDocumentIdentifier& textDocument,
-                const TextDocumentContentChangeEvents& contentChanges );
+            class RenameRegistrationOptions : public TextDocumentRegistrationOptions
+            {
+              public:
+                RenameRegistrationOptions( const Data& data );
 
-            VersionedTextDocumentIdentifier textDocument( void ) const;
+                RenameRegistrationOptions( const DocumentSelector& selector );
 
-            TextDocumentContentChangeEvents contentChanges( void ) const;
+                u1 hasPrepareProvider( void ) const;
 
-            static void validate( const Data& data );
-        };
+                void setPrepareProvider( const u1 prepareProvider );
 
-        enum class TextDocumentSaveReason
-        {
-            Manual = 1,      // by the user pressing save, by starting debugging, or by an API call.
-            AfterDelay = 2,  // Automatic after a delay.
-            FocusOut = 3     //  When the editor lost focus.
-        };
+                u1 prepareProvider( void ) const;
 
-        class WillSaveTextDocumentParams : public Data
-        {
-          public:
-            WillSaveTextDocumentParams( const Data& data );
+                static void validate( const Data& data );
+            };
 
-            WillSaveTextDocumentParams(
-                const TextDocumentIdentifier& textDocument, TextDocumentSaveReason reason );
+            class RenameResult : public Data
+            {
+              public:
+                RenameResult( void );
 
-            TextDocumentSaveReason reason( void ) const;
+                RenameResult( const Data& data );
 
-            TextDocumentIdentifier textDocument( void ) const;
+                RenameResult( const WorkspaceEdit& edit );
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        using TextEdits = std::vector< TextEdit >;
+            using PrepareRenameParams = TextDocumentPositionParams;
 
-        class WillSaveWaitUntilResponse : public Data
-        {
-          public:
-            WillSaveWaitUntilResponse( const Data& data );
+            class PrepareRenameResult : public Data
+            {
+              public:
+                PrepareRenameResult( void );
 
-            WillSaveWaitUntilResponse( const std::vector< TextEdit >& textEdit );
+                PrepareRenameResult( const Data& data );
 
-            TextEdits textEdit( void ) const;
+                PrepareRenameResult( const Range& range, const std::string& placeholder );
 
-            static void validate( const Data& data );
-        };
+                static void validate( const Data& data );
+            };
 
-        class DidSaveTextDocumentParams : public Data
-        {
-          public:
-            DidSaveTextDocumentParams( const Data& data );
+            class FoldingRangeParams : public Data
+            {
+              public:
+                FoldingRangeParams( const Data& data );
 
-            DidSaveTextDocumentParams( const TextDocumentIdentifier& textDocument );
+                FoldingRangeParams( const TextDocumentIdentifier& textDocument );
 
-            u1 hasText( void ) const;
+                TextDocumentIdentifier textDocument( void ) const;
 
-            void setText( const std::string& text );
+                static void validate( const Data& data );
+            };
+            enum class FoldingRangeKind
+            {
+                Comment,
+                Imports,
+                Region
+            };
 
-            TextDocumentIdentifier textDocument( void ) const;
+            class FoldingRange : public Data
+            {
+              public:
+                FoldingRange( const Data& data );
 
-            std::string text( void ) const;
+                FoldingRange( const std::size_t startLine, const std::size_t endLine );
 
-            static void validate( const Data& data );
-        };
-        class DidCloseTextDocumentParams : public Data
-        {
-          public:
-            DidCloseTextDocumentParams( const TextDocumentIdentifier& textDocument );
+                std::size_t startLine( void ) const;
 
-            DidCloseTextDocumentParams( const Data& data );
+                std::size_t endLine( void ) const;
 
-            TextDocumentIdentifier textDocument( void ) const;
+                u1 hasStartCharacter( void ) const;
 
-            static void validate( const Data& data );
-        };
+                void setStartCharacter( const std::size_t startCharacter );
 
-        class CompletionRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            CompletionRegistrationOptions( const Data& data );
+                std::size_t startCharacter( void ) const;
 
-            CompletionRegistrationOptions( const DocumentSelector& documentSelector );
+                u1 hasEndCharacter( void ) const;
 
-            u1 hasTriggerCharacters( void ) const;
+                void setEndCharacter( const std::size_t endCharacter );
 
-            TriggerCharacters triggerCharacters( void ) const;
+                std::size_t endCharacter( void ) const;
 
-            void addTriggerCharacter( const std::string& triggerCharacter );
+                u1 hasKind( void ) const;
 
-            u1 hasResolveProvider( void ) const;
+                void setKind( const FoldingRangeKind kind );
 
-            u1 resolveProvider( void ) const;
+                std::string kind( void ) const;
 
-            void setResolveProvider( const u1 resolveProvider );
+                static void validate( const Data& data );
+            };
+            using FoldingRanges = std::vector< FoldingRange >;
+            class FoldingRangeResult : public Data
+            {
+              public:
+                FoldingRangeResult( void );
 
-            static void validate( const Data& data );
-        };
+                FoldingRangeResult( const Data& data );
 
-        enum class CompletionTriggerKind
-        {
-            /**
-             * Completion was triggered by typing an identifier (24x7 code
-             * complete), manual invocation (e.g Ctrl+Space) or via API.
-             */
-            Invoked = 1,
+                FoldingRangeResult( const FoldingRanges ranges );
 
-            /**
-             * Completion was triggered by a trigger character specified by
-             * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-             */
-            TriggerCharacter = 2,
+                static void validate( const Data& data );
+            };
 
-            /**
-             * Completion was re-triggered as the current completion list is incomplete.
-             */
-            TriggerForIncompleteCompletions = 3
-        };
+            class ExecuteCommandParams : public Data
+            {
+              public:
+                ExecuteCommandParams( const Data& data );
 
-        class CompletionContext : public Data
-        {
-          public:
-            CompletionContext( const Data& data );
+                ExecuteCommandParams( const std::string& command );
 
-            CompletionContext( const CompletionTriggerKind triggerkind );
+                std::string command( void ) const;
 
-            std::string triggerCharacter( void ) const;
+                u1 hasArguments( void ) const;
 
-            void setTriggerCharacter( const std::string& triggerCharacter );
+                Data arguments( void ) const;
 
-            u1 hasTriggerCharacter( void ) const;
+                void addArgument( const Data& argument );
 
-            CompletionTriggerKind triggerKind( void ) const;
+                static void validate( const Data& data );
+            };
 
-            static void validate( const Data& data );
-        };
-
-        class CompletionParams : public TextDocumentPositionParams
-        {
-          public:
-            CompletionParams( const Data& data );
-
-            CompletionParams(
-                const TextDocumentIdentifier& textDocument, const Position& position );
-
-            CompletionContext context( void ) const;
-
-            u1 hasContext( void ) const;
-
-            void setContext( const CompletionContext& context );
-
-            static void validate( const Data& data );
-        };
-
-        enum class MarkupKind
-        {
-            PLAINTEXT,
-            MARKDOWN
-        };
-
-        class MarkupContent : public Data
-        {
-          public:
-            MarkupContent( const Data& data );
-
-            MarkupContent( const std::string& value );  // kind will be plaintext
-
-            MarkupContent( const MarkupKind kind, const std::string& value );
-
-            std::string kind( void ) const;
-
-            std::string value( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        enum class InsertTextFormat
-        {
-            PlainText = 1,
-            Snippet = 2
-        };
-
-        enum class CompletionItemKind
-        {
-            Text = 1,
-            Method = 2,
-            Function = 3,
-            Constructor = 4,
-            Field = 5,
-            Variable = 6,
-            Class = 7,
-            Interface = 8,
-            Module = 9,
-            Property = 10,
-            Unit = 11,
-            Value = 12,
-            Enum = 13,
-            Keyword = 14,
-            Snippet = 15,
-            Color = 16,
-            File = 17,
-            Reference = 18,
-            Folder = 19,
-            EnumMember = 20,
-            Constant = 21,
-            Struct = 22,
-            Event = 23,
-            Operator = 24,
-            TypeParameter = 25
-        };
-
-        using CommitCharacters = std::vector< std::string >;
-
-        class CompletionItem : public Data
-        {
-          public:
-            CompletionItem( const Data& data );
-
-            CompletionItem( const std::string& label );
-
-            std::string label( void ) const;
-
-            u1 hasKind( void ) const;
-
-            void setKind( const CompletionItemKind kind );
-
-            CompletionItemKind kind( void ) const;
-
-            u1 hasDetail( void ) const;
-
-            void setDetail( const std::string& detail );
-
-            std::string detail( void ) const;
-
-            u1 hasDocumentation( void ) const;
-
-            void setDocumentation( const MarkupContent& doc );
-
-            MarkupContent documentation( void ) const;
-
-            u1 hasDeprecated( void ) const;
-
-            void setDeprecated( const u1 deprecated );
-
-            u1 isDeprecated( void ) const;
-
-            u1 hasPreselected( void ) const;
-
-            void setPreselected( const u1 preselected );
-
-            u1 isPreselected( void ) const;
-
-            u1 hasSortText( void ) const;
-
-            void setSortText( const std::string& sortText );
-
-            std::string sortText( void ) const;
-
-            u1 hasFilterText( void ) const;
-
-            void setFilterText( const std::string& filterText );
-
-            std::string filterText( void ) const;
-
-            u1 hasInsertText( void ) const;
-
-            void setInsertText( const std::string& insertText );
-
-            std::string insertText( void ) const;
-
-            u1 hasInsertTextFormat( void ) const;
-
-            void setInsertTextFormat( const InsertTextFormat insertTextFormat );
-
-            InsertTextFormat insertTextFormat( void ) const;
-
-            u1 hasTextEdit( void ) const;
-
-            void setTextEdit( const TextEdit& textEdit );
-
-            TextEdit textEdit( void ) const;
-
-            u1 hasAdditionalTextEdits( void ) const;
-
-            void addAdditionalTextEdit( const TextEdit& textEdit );
-
-            TextEdits additionalTextEdits( void ) const;
-
-            u1 hasCommitCharacters( void ) const;
-
-            void addCommitCharacter( const std::string& commitCharacter );
-
-            CommitCharacters commitCharacters( void ) const;
-
-            u1 hasCommand( void ) const;
-
-            void setCommand( const Command& command );
-
-            Command command( void ) const;
-
-            u1 hasData( void ) const;
-
-            void setData( const Data& data );
-
-            Data data( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using CompletionItems = std::vector< CompletionItem >;
-        class CompletionList : public Data
-        {
-          public:
-            CompletionList( const Data& data );
-
-            CompletionList( const u1 isIncomplete, const CompletionItems& items );
-
-            CompletionItems items( void ) const;
-
-            u1 isIncomplete( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using CompletionResolveResult = CompletionItem;
-
-        using SignatureHelpParams = TextDocumentPositionParams;
-
-        class CompletionResult : public Data
-        {
-          public:
-            CompletionResult( void );
-
-            CompletionResult( const Data& data );
-
-            CompletionResult( const CompletionList& list );
-
-            CompletionResult( const CompletionItems& items );
-
-            static void validate( const Data& data );
-        };
-
-        class ParameterInformation : public Data
-        {
-          public:
-            ParameterInformation( const Data& data );
-
-            ParameterInformation( const std::string& label );
-
-            std::string label( void ) const;
-
-            MarkupContent documentation( void ) const;
-
-            u1 hasDocumentation( void ) const;
-
-            void setDocumentation( const MarkupContent& doc );
-
-            static void validate( const Data& data );
-        };
-
-        using ParameterInformations = std::vector< ParameterInformation >;
-        class SignatureInformation : public Data
-        {
-          public:
-            SignatureInformation( const Data& data );
-
-            SignatureInformation( const std::string& label );
-
-            std::string label( void ) const;
-
-            MarkupContent documentation( void ) const;
-
-            u1 hasDocumentation( void ) const;
-
-            void setDocumentation( const MarkupContent& doc );
-
-            u1 hasParameters( void ) const;
-
-            ParameterInformations parameters( void ) const;
-
-            void setParameters( const ParameterInformations& parameters );
-
-            static void validate( const Data& data );
-        };
-
-        using SignatureInformations = std::vector< SignatureInformation >;
-        class SignatureHelp : public Data
-        {
-          public:
-            SignatureHelp( const Data& data );
-
-            SignatureHelp( const SignatureInformations& signatures );
-
-            SignatureInformations signatures( void ) const;
-
-            u1 hasActiveSignature( void ) const;
-
-            void setActiveSignature( const std::size_t activeSignature );
-
-            std::size_t activeSignature( void ) const;
-
-            u1 hasActiveParameter( void ) const;
-
-            void setActiveParameter( const std::size_t activeParameter );
-
-            std::size_t activeParameter( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class SignatureHelpResult : public Data
-        {
-          public:
-            SignatureHelpResult( void );
-
-            SignatureHelpResult( const Data& data );
-
-            SignatureHelpResult( const SignatureHelp& signature );
-
-            static void validate( const Data& data );
-        };
-
-        using TypeDefinitionParams = TextDocumentPositionParams;
-
-        using Locations = std::vector< Location >;
-
-        class LocationLink : public Data
-        {
-          public:
-            LocationLink( const Data& data );
-
-            LocationLink( const DocumentUri& targetUri, const Range& targetRange );
-
-            DocumentUri targetUri( void ) const;
-
-            Range targetRange( void ) const;
-
-            u1 hasOriginSelectionRange( void ) const;
-
-            void setOriginSelectionRange( const Range& range );
-
-            Range originSelectionRange( void ) const;
-
-            u1 hasTargetSelectionRange( void ) const;
-
-            void setTargetSelectionRange( const Range& range );
-
-            Range targetSelectionRange( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using LocationLinks = std::vector< LocationLink >;
-
-        class TypeDefinitionResult : public Data
-        {
-          public:
-            TypeDefinitionResult( const Data& data );
-
-            TypeDefinitionResult( const Locations& locations );
-
-            TypeDefinitionResult( const LocationLinks& locationLinks );
-
-            TypeDefinitionResult( const Location& location );
-
-            static void validate( const Data& data );
-        };
-
-        using TextDocumentImplementationResult = TypeDefinitionResult;
-
-        using TextDocumentImplementationParams = TextDocumentPositionParams;
-
-        class ReferenceContext : public Data
-        {
-          public:
-            ReferenceContext( const Data& data );
-
-            ReferenceContext( const u1 includeDeclaration );
-
-            u1 includeDeclaration( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class ReferenceParams : public TextDocumentPositionParams
-        {
-          public:
-            ReferenceParams( const Data& data );
-
-            ReferenceParams(
-                const TextDocumentIdentifier& textDocument,
-                const Position& position,
-                const ReferenceContext& context );
-
-            ReferenceContext context( void ) const;
-
-            static void validate( const Data& data );
-        };
-        class ReferenceResult : public Data
-        {
-          public:
-            ReferenceResult( const Data& data );
-
-            ReferenceResult( const Locations& locations );
-
-            static void validate( const Data& data );
-        };
-
-        enum class CodeActionKind
-        {
-            QuickFix,
-            Refactor,
-            RefactorExtract,
-            RefactorInline,
-            RefactorRewrite,
-            Source,
-            SourceOrganizeImports
-        };
-
-        class CodeActionOptions : public Data
-        {
-          public:
-            CodeActionOptions( const Data& data );
-
-            u1 hasCodeActionKinds( void ) const;
-
-            void addCodeActionKind( CodeActionKind kind );
-
-            std::vector< std::string > codeActionKinds( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using Diagnostics = std::vector< Diagnostic >;
-
-        class CodeActionContext : public Data
-        {
-          public:
-            CodeActionContext( const Data& data );
-
-            CodeActionContext( const Diagnostics& diagnostics );
-
-            Diagnostics diagnostics( void ) const;
-
-            u1 hasKind( void ) const;
-
-            void setKind( const CodeActionKind kind );
-
-            std::string kind( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class CodeActionParams : public Data
-        {
-          public:
-            CodeActionParams( const Data& data );
-
-            CodeActionParams(
-                const TextDocumentIdentifier& textDocument,
-                const Range& range,
-                const CodeActionContext& context );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            Range range( void ) const;
-
-            CodeActionContext context( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class CodeAction : public Data
-        {
-          public:
-            CodeAction( const Data& data );
-
-            CodeAction( const std::string& title );
-
-            std::string title( void ) const;
-
-            u1 hasKind( void ) const;
-
-            std::string kind( void ) const;
-
-            void setKind( const CodeActionKind kind );
-
-            u1 hasDiagnostics( void ) const;
-
-            Diagnostics diagnostics( void ) const;
-
-            void addDiagnostic( const Diagnostic& diagnostic );
-
-            u1 hasEdit( void ) const;
-
-            WorkspaceEdit edit( void ) const;
-
-            void setEdit( const WorkspaceEdit& edit );
-
-            void setCommand( const Command& command );
-
-            u1 hasCommand( void ) const;
-
-            Command command( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class CodeActionResult : public Data
-        {
-          public:
-            CodeActionResult( const Data& data );
-
-            CodeActionResult( const std::vector< Command >& commands );
-
-            CodeActionResult( void );
-
-            void addCommand( const Command& command );
-
-            static void validate( const Data& data );
-        };
-
-        class CodeActionRegistrationOptions
-        : public TextDocumentRegistrationOptions
-        , public CodeActionOptions
-        {
-        };
-
-        class PublishDiagnosticsParams : public Data
-        {
-          public:
-            PublishDiagnosticsParams( const Data& data );
-
-            PublishDiagnosticsParams(
-                const DocumentUri& uri, const std::vector< Diagnostic >& diagnostics );
-
-            DocumentUri uri( void ) const;
-
-            Data diagnostics( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using HoverParams = TextDocumentPositionParams;
-
-        class MarkedString : public Data
-        {
-          public:
-            MarkedString( const Data& data );
-
-            MarkedString( const std::string& language, const std::string& value );
-
-            std::string language( void ) const;
-
-            std::string value( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class HoverResult : public Data
-        {
-          public:
-            HoverResult( const Data& data );
-
-            HoverResult( const std::vector< MarkedString >& contents = {} );
-
-            Data contents( void ) const;
-
-            void addContent( const MarkedString& content );
-
-            u1 hasRange( void ) const;
-
-            Range range( void ) const;
-
-            void setRange( const Range& range );
-
-            static void validate( const Data& data );
-        };
-
-        using DefinitionParams = TextDocumentPositionParams;
-
-        class DefinitionResult : public Data
-        {
-          public:
-            DefinitionResult( const Data& data );
-
-            DefinitionResult( const Location& location );
-
-            DefinitionResult( const std::vector< Location > locations );
-
-            Data locations( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using DocumentHighlightParams = TextDocumentPositionParams;
-
-        enum class DocumentHighlightKind
-        {
-            Text = 1,
-            Read = 2,
-            Write = 3
-        };
-
-        class DocumentHighlight : public Data
-        {
-          public:
-            DocumentHighlight( const Data& data );
-
-            DocumentHighlight( const Range& range );
-
-            Range range( void ) const;
-
-            u1 hasKind( void ) const;
-
-            DocumentHighlightKind kind( void ) const;
-
-            void setKind( const DocumentHighlightKind kind );
-
-            static void validate( const Data& data );
-        };
-        using DocumentHighlights = std::vector< DocumentHighlight >;
-
-        class DocumentHighlightResult : public Data
-        {
-          public:
-            DocumentHighlightResult( void );
-
-            DocumentHighlightResult( const Data& data );
-
-            DocumentHighlightResult( const DocumentHighlights& highlights );
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentSymbolParams : public Data
-        {
-          public:
-            DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
-
-            DocumentSymbolParams( const Data& data );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentSymbol;
-
-        using DocumentSymbols = std::vector< DocumentSymbol >;
-
-        class DocumentSymbol : public Data
-        {
-          public:
-            DocumentSymbol( const Data& data );
-
-            DocumentSymbol(
-                const std::string& name, const SymbolKind kind, Range range, Range selectionRange );
-
-            std::string name( void ) const;
-
-            SymbolKind kind( void ) const;
-
-            Range range( void ) const;
-
-            Range selectionRange( void ) const;
-
-            u1 hasDetail( void ) const;
-
-            void setDetail( const std::string& detail );
-
-            std::string detail( void ) const;
-
-            u1 hasDeprecated( void ) const;
-
-            u1 deprecated( void ) const;
-
-            void setDeprecated( const u1 deprecated );
-
-            u1 hasChildren( void ) const;
-
-            DocumentSymbols children( void ) const;
-
-            void addChild( const DocumentSymbol& symbol );
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentSymbolResult : public Data
-        {
-          public:
-            DocumentSymbolResult( void );
-
-            DocumentSymbolResult( const Data& data );
-
-            DocumentSymbolResult( const DocumentSymbols& symbols );
-
-            DocumentSymbolResult( const SymbolInformations& information );
-
-            static void validate( const Data& data );
-        };
-
-        class CodeLensParams : public Data
-        {
-          public:
-            CodeLensParams( const Data& data );
-
-            CodeLensParams( const TextDocumentIdentifier& textDocument );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class CodeLens : public Data
-        {
-          public:
-            CodeLens( const Data& data );
-
-            CodeLens( const Range& range );
-
-            Range range( void ) const;
-
-            u1 hasCommand( void ) const;
-
-            Command command( void ) const;
-
-            void setCommand( const Command& command );
-
-            u1 hasData( void ) const;
-
-            Data data( void ) const;
-
-            void setData( const Data& data );
-
-            static void validate( const Data& data );
-        };
-
-        class CodeLensResult : public Data
-        {
-          public:
-            CodeLensResult( const Data& data );
-
-            CodeLensResult( const std::vector< CodeLens >& codeLens = {} );
-
-            void addCodeLens( const CodeLens& codeLens );
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentLinkParams : public Data
-        {
-          public:
-            DocumentLinkParams( const Data& data );
-
-            DocumentLinkParams( const TextDocumentIdentifier& textDocument );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentLink : public Data
-        {
-          public:
-            DocumentLink( const Data& data );
-
-            DocumentLink( const Range& range );
-
-            Range range( void ) const;
-
-            u1 hasTarget( void ) const;
-
-            void setTarget( const DocumentUri& target );
-
-            DocumentUri target( void ) const;
-
-            u1 hasData( void ) const;
-
-            void setData( const Data& data );
-
-            Data data( void ) const;
-
-            static void validate( const Data& data );
-        };
-        using DocumentLinks = std::vector< DocumentLink >;
-        class DocumentLinkResult : public Data
-        {
-          public:
-            DocumentLinkResult( void );
-
-            DocumentLinkResult( const Data& data );
-
-            DocumentLinkResult( const DocumentLinks links );
-
-            static void validate( const Data& data );
-        };
-
-        using CodeLensResolveParams = CodeLens;
-        using CodeLensResolveResult = CodeLens;
-        using DocumentLinkResolveResult = DocumentLink;
-        using DocumentLinkResolveParams = DocumentLink;
-
-        class DocumentColorParams : public Data
-        {
-          public:
-            DocumentColorParams( const Data& data );
-
-            DocumentColorParams( const TextDocumentIdentifier& textDocument );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class Color : public Data
-        {
-          public:
-            Color( const Data& data );
-
-            Color( const float red, const float green, const float blue, const float alpha );
-
-            float red( void ) const;
-
-            float green( void ) const;
-
-            float blue( void ) const;
-
-            float alpha( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class ColorInformation : public Data
-        {
-          public:
-            ColorInformation( const Data& data );
-
-            ColorInformation( const Range& range, const Color& color );
-
-            Range range( void ) const;
-
-            Color color( void ) const;
-
-            static void validate( const Data& data );
-        };
-        using ColorInformations = std::vector< ColorInformation >;
-
-        class DocumentColorResult : public Data
-        {
-          public:
-            DocumentColorResult( const Data& data );
-
-            DocumentColorResult( const ColorInformations& colorInformations );
-
-            static void validate( const Data& data );
-        };
-
-        class ColorPresentationParams : public DocumentColorParams
-        {
-          public:
-            ColorPresentationParams( const Data& data );
-
-            ColorPresentationParams(
-                const TextDocumentIdentifier& textDocument,
-                const Color& color,
-                const Range& range );
-
-            Color color( void ) const;
-
-            Range range( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class ColorPresentation : public Data
-        {
-          public:
-            ColorPresentation( const Data& data );
-
-            ColorPresentation( const std::string& label );
-
-            std::string label( void ) const;
-
-            u1 hasTextEdit( void ) const;
-
-            void setTextEdit( const TextEdit& textEdit );
-
-            TextEdit textEdit( void ) const;
-
-            u1 hasAdditionalTextEdits( void ) const;
-
-            void addAdditionalTextEdit( const TextEdit& textEdit );
-
-            TextEdits additionalTextEdits( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using ColorPresentations = std::vector< ColorPresentation >;
-
-        class ColorPresentationResult : public Data
-        {
-          public:
-            ColorPresentationResult( const Data& data );
-
-            ColorPresentationResult( ColorPresentations presentations );
-
-            static void validate( const Data& data );
-        };
-
-        class FormattingOptions : public Data
-        {
-          private:
-            static void validateAdditionalOptions( const Data& data );
-
-          public:
-            FormattingOptions( const Data& data );
-
-            FormattingOptions( const std::size_t tabSize, const u1 insertSpaces );
-
-            std::size_t tabSize( void ) const;
-
-            void addBool( const std::string& key, const u1 boolean );
-
-            void addNumber( const std::string& key, const float number );
-
-            void addString( const std::string& key, const std::string& string );
-
-            u1 insertSpaces( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentFormattingParams : public Data
-        {
-          public:
-            DocumentFormattingParams( const Data& data );
-
-            DocumentFormattingParams(
-                const TextDocumentIdentifier& textDocument, const FormattingOptions& options );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            FormattingOptions options( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentFormattingResult : public Data
-        {
-          public:
-            DocumentFormattingResult( void );
-
-            DocumentFormattingResult( const Data& data );
-
-            DocumentFormattingResult( const TextEdits& edits );
-
-            static void validate( const Data& data );
-        };
-        class DocumentRangeFormattingParams : public DocumentFormattingParams
-        {
-          public:
-            DocumentRangeFormattingParams( const Data& data );
-
-            DocumentRangeFormattingParams(
-                const TextDocumentIdentifier& textDocument,
-                const Range& range,
-                const FormattingOptions& options );
-
-            Range range( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentOnTypeFormattingParams : public DocumentFormattingParams
-        {
-          public:
-            DocumentOnTypeFormattingParams( const Data& data );
-
-            DocumentOnTypeFormattingParams(
-                const TextDocumentIdentifier& textDocument,
-                const FormattingOptions& options,
-                const Position& position,
-                const std::string& ch );
-
-            Position position( void ) const;
-
-            std::string ch( void ) const;  // character that has been typed.
-
-            static void validate( const Data& data );
-        };
-
-        class DocumentOnTypeFormattingRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            DocumentOnTypeFormattingRegistrationOptions( const Data& data );
-
-            DocumentOnTypeFormattingRegistrationOptions(
-                const DocumentSelector& documentSelector,
-                const std::string& firstTriggerCharacter );
-
-            std::string firstTriggerCharacter( void ) const;
-
-            u1 hasMoreTriggerCharacter( void ) const;
-
-            void addMoreTriggerCharacter( const std::string& character );
-
-            std::vector< std::string > moreTriggerCharacter( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        using DocumentOnTypeFormattingResult = DocumentFormattingResult;
-
-        using DocumentRangeFormattingResult = DocumentFormattingResult;
-
-        class RenameParams : public Data
-        {
-          public:
-            RenameParams( const Data& data );
-
-            RenameParams(
-                const TextDocumentIdentifier& textDocument,
-                const Position& position,
-                const std::string& newName );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            Position position( void ) const;
-
-            std::string newName( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class RenameRegistrationOptions : public TextDocumentRegistrationOptions
-        {
-          public:
-            RenameRegistrationOptions( const Data& data );
-
-            RenameRegistrationOptions( const DocumentSelector& selector );
-
-            u1 hasPrepareProvider( void ) const;
-
-            void setPrepareProvider( const u1 prepareProvider );
-
-            u1 prepareProvider( void ) const;
-
-            static void validate( const Data& data );
-        };
-
-        class RenameResult : public Data
-        {
-          public:
-            RenameResult( void );
-
-            RenameResult( const Data& data );
-
-            RenameResult( const WorkspaceEdit& edit );
-
-            static void validate( const Data& data );
-        };
-
-        using PrepareRenameParams = TextDocumentPositionParams;
-
-        class PrepareRenameResult : public Data
-        {
-          public:
-            PrepareRenameResult( void );
-
-            PrepareRenameResult( const Data& data );
-
-            PrepareRenameResult( const Range& range, const std::string& placeholder );
-
-            static void validate( const Data& data );
-        };
-
-        class FoldingRangeParams : public Data
-        {
-          public:
-            FoldingRangeParams( const Data& data );
-
-            FoldingRangeParams( const TextDocumentIdentifier& textDocument );
-
-            TextDocumentIdentifier textDocument( void ) const;
-
-            static void validate( const Data& data );
-        };
-        enum class FoldingRangeKind
-        {
-            Comment,
-            Imports,
-            Region
-        };
-
-        class FoldingRange : public Data
-        {
-          public:
-            FoldingRange( const Data& data );
-
-            FoldingRange( const std::size_t startLine, const std::size_t endLine );
-
-            std::size_t startLine( void ) const;
-
-            std::size_t endLine( void ) const;
-
-            u1 hasStartCharacter( void ) const;
-
-            void setStartCharacter( const std::size_t startCharacter );
-
-            std::size_t startCharacter( void ) const;
-
-            u1 hasEndCharacter( void ) const;
-
-            void setEndCharacter( const std::size_t endCharacter );
-
-            std::size_t endCharacter( void ) const;
-
-            u1 hasKind( void ) const;
-
-            void setKind( const FoldingRangeKind kind );
-
-            std::string kind( void ) const;
-
-            static void validate( const Data& data );
-        };
-        using FoldingRanges = std::vector< FoldingRange >;
-        class FoldingRangeResult : public Data
-        {
-          public:
-            FoldingRangeResult( void );
-
-            FoldingRangeResult( const Data& data );
-
-            FoldingRangeResult( const FoldingRanges ranges );
-
-            static void validate( const Data& data );
-        };
-
-        class ExecuteCommandParams : public Data
-        {
-          public:
-            ExecuteCommandParams( const Data& data );
-
-            ExecuteCommandParams( const std::string& command );
-
-            std::string command( void ) const;
-
-            u1 hasArguments( void ) const;
-
-            Data arguments( void ) const;
-
-            void addArgument( const Data& argument );
-
-            static void validate( const Data& data );
-        };
-
-        using ExecuteCommandResult = Data;  // TODO: PPA: FIXME:
+            using ExecuteCommandResult = Data;  // TODO: PPA: FIXME:
+        }
     }
-}
 }
 
 #endif  // _LIBSTDHL_CPP_NETWORK_LSP_CONTENT_H_

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -151,6 +151,8 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            using Locations = std::vector< Location >;
+
             enum class DiagnosticSeverity : std::size_t
             {
                 Error = 1,
@@ -227,6 +229,8 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
+            using Commands = std::vector< Command >;
 
             class TextEdit : public Data
             {
@@ -931,6 +935,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             class StaticRegistrationOptions : public Data
             {
               public:
@@ -1469,7 +1474,7 @@ namespace libstdhl
             class UnregistrationParams : public Data
             {
               public:
-                UnregistrationParams( const std::vector< Unregistration >& unregistrations );
+                UnregistrationParams( const Unregistrations& unregistrations );
 
                 UnregistrationParams( const Data& data );
 
@@ -1487,7 +1492,7 @@ namespace libstdhl
 
                 WorkspaceFoldersResult( const WorkspaceFolders& workspaceFolders );
 
-                WorkspaceFolders toVec( void ) const;
+                WorkspaceFolders workspaceFolders( void ) const;
 
                 static void validate( const Data& data );
             };
@@ -1731,7 +1736,7 @@ namespace libstdhl
               public:
                 WorkspaceSymbolResult( const Data& data );
 
-                WorkspaceSymbolResult( const std::vector< SymbolInformation >& symbolInformation );
+                WorkspaceSymbolResult( const SymbolInformations& symbolInformation );
 
                 void addSymbolInformation( const SymbolInformation& information );
 
@@ -1837,7 +1842,8 @@ namespace libstdhl
                 WillSaveTextDocumentParams( const Data& data );
 
                 WillSaveTextDocumentParams(
-                    const TextDocumentIdentifier& textDocument, TextDocumentSaveReason reason );
+                    const TextDocumentIdentifier& textDocument,
+                    const TextDocumentSaveReason reason );
 
                 TextDocumentSaveReason reason( void ) const;
 
@@ -1853,7 +1859,7 @@ namespace libstdhl
               public:
                 WillSaveWaitUntilResponse( const Data& data );
 
-                WillSaveWaitUntilResponse( const std::vector< TextEdit >& textEdit );
+                WillSaveWaitUntilResponse( const TextEdits& textEdit );
 
                 TextEdits textEdit( void ) const;
 
@@ -2330,7 +2336,7 @@ namespace libstdhl
 
                 u1 hasCodeActionKinds( void ) const;
 
-                void addCodeActionKind( CodeActionKind kind );
+                void addCodeActionKind( const CodeActionKind kind );
 
                 std::vector< std::string > codeActionKinds( void ) const;
 
@@ -2417,7 +2423,7 @@ namespace libstdhl
               public:
                 CodeActionResult( const Data& data );
 
-                CodeActionResult( const std::vector< Command >& commands );
+                CodeActionResult( const Commands& commands );
 
                 CodeActionResult( void );
 
@@ -2437,12 +2443,11 @@ namespace libstdhl
               public:
                 PublishDiagnosticsParams( const Data& data );
 
-                PublishDiagnosticsParams(
-                    const DocumentUri& uri, const std::vector< Diagnostic >& diagnostics );
+                PublishDiagnosticsParams( const DocumentUri& uri, const Diagnostics& diagnostics );
 
                 DocumentUri uri( void ) const;
 
-                Data diagnostics( void ) const;
+                Diagnostics diagnostics( void ) const;
 
                 static void validate( const Data& data );
             };
@@ -2463,14 +2468,16 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            using MarkedStrings = std::vector< MarkedString >;
+
             class HoverResult : public Data
             {
               public:
                 HoverResult( const Data& data );
 
-                HoverResult( const std::vector< MarkedString >& contents = {} );
+                HoverResult( const MarkedStrings& contents = {} );
 
-                Data contents( void ) const;
+                MarkedStrings contents( void ) const;
 
                 void addContent( const MarkedString& content );
 
@@ -2492,9 +2499,9 @@ namespace libstdhl
 
                 DefinitionResult( const Location& location );
 
-                DefinitionResult( const std::vector< Location > locations );
+                DefinitionResult( const Locations& locations );
 
-                Data locations( void ) const;
+                Locations locations( void ) const;
 
                 static void validate( const Data& data );
             };
@@ -2525,16 +2532,17 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
             using DocumentHighlights = std::vector< DocumentHighlight >;
 
             class DocumentHighlightResult : public Data
             {
               public:
-                DocumentHighlightResult( void );
-
                 DocumentHighlightResult( const Data& data );
 
                 DocumentHighlightResult( const DocumentHighlights& highlights );
+
+                DocumentHighlightResult( void );
 
                 static void validate( const Data& data );
             };
@@ -2542,9 +2550,9 @@ namespace libstdhl
             class DocumentSymbolParams : public Data
             {
               public:
-                DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
-
                 DocumentSymbolParams( const Data& data );
+
+                DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
 
                 TextDocumentIdentifier textDocument( void ) const;
 
@@ -2563,8 +2571,8 @@ namespace libstdhl
                 DocumentSymbol(
                     const std::string& name,
                     const SymbolKind kind,
-                    Range range,
-                    Range selectionRange );
+                    const Range& range,
+                    const Range& selectionRange );
 
                 std::string name( void ) const;
 
@@ -3046,11 +3054,11 @@ namespace libstdhl
             class FoldingRangeResult : public Data
             {
               public:
-                FoldingRangeResult( void );
-
                 FoldingRangeResult( const Data& data );
 
-                FoldingRangeResult( const FoldingRanges ranges );
+                FoldingRangeResult( const FoldingRanges& ranges );
+
+                FoldingRangeResult( void );
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2303,6 +2303,32 @@ namespace libstdhl
 
             using Locations = std::vector< Location >;
 
+            class LocationLink : public Data
+            {
+              public:
+                LocationLink( const Data& data );
+
+                LocationLink( const DocumentUri& targetUri, const Range& targetRange );
+
+                DocumentUri targetUri( void ) const;
+
+                Range targetRange( void ) const;
+
+                u1 hasOriginSelectionRange( void ) const;
+
+                void setOriginSelectionRange( const Range& range );
+
+                Range originSelectionRange( void ) const;
+
+                u1 hasTargetSelectionRange( void ) const;
+
+                void setTargetSelectionRange( const Range& range );
+
+                Range targetSelectionRange( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class TypeDefinitionResult : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -678,6 +678,18 @@ namespace libstdhl
 
                 void executeCommand( const DynamicRegistration& executeCommand );
 
+                u1 hasWorkspaceFolders( void ) const;
+
+                void setWorkspaceFolders( const u1 workspaceFolders );
+
+                u1 workspaceFolders( void ) const;
+
+                u1 hasConfiguration( void ) const;
+
+                void setConfiguration( const u1 configuration );
+
+                u1 configuration( void ) const;
+
                 static void validate( const Data& data );
             };
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1032,6 +1032,20 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            class RenameOptions : public Data
+            {
+              public:
+                RenameOptions( const Data& data );
+
+                u1 hasPrepareProvider( void ) const;
+
+                u1 prepareProvider( void ) const;
+
+                void setPrepareProvider( const u1 prepareProvider );
+
+                static void validate( const Data& data );
+            };
+
             using DocumentLinkOptions = CodeLensOptions;
 
             class ExecuteCommandOptions : public Data

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1420,7 +1420,16 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
-            using ConfigurationResult = Data;
+
+            class ConfigurationResult : public Data
+            {
+              public:
+                ConfigurationResult( void );
+
+                ConfigurationResult( const Data& data );
+
+                static void validate( const Data& data );
+            };
 
             using ConfigurationItems = std::vector< ConfigurationItem >;
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -475,6 +475,30 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            using RenameFileOptions = CreateFileOptions;
+
+            class RenameFile : public Data
+            {
+              public:
+                RenameFile( const Data& data );
+
+                RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri );
+
+                DocumentUri newUri( void ) const;
+
+                DocumentUri oldUri( void ) const;
+
+                std::string kind( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const CreateFileOptions& options );
+
+                CreateFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class TextDocumentItem : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -306,6 +306,21 @@ namespace libstdhl
                 Hint = 4,
             };
 
+            class DiagnosticRelatedInformation : public Data
+            {
+              public:
+                DiagnosticRelatedInformation( const Data& data );
+
+                DiagnosticRelatedInformation(
+                    const Location& location, const std::string& message );
+
+                Location location( void ) const;
+
+                std::string message( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class Diagnostic : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2895,11 +2895,11 @@ namespace libstdhl
                     const TextDocumentIdentifier& textDocument,
                     const FormattingOptions& options,
                     const Position& position,
-                    const std::string& ch );
+                    const std::string& character );
 
                 Position position( void ) const;
 
-                std::string ch( void ) const;  // character that has been typed.
+                std::string character( void ) const; 
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1160,6 +1160,22 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            class WorkspaceFolder : public Data
+            {
+              public:
+                WorkspaceFolder( const std::string& uri, const std::string& name );
+
+                WorkspaceFolder( const Data& data );
+
+                std::string uri( void ) const;
+
+                std::string name( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            using WorkspaceFolders = std::vector< WorkspaceFolder >;
+
             class InitializeParams : public Data
             {
               public:
@@ -1189,6 +1205,12 @@ namespace libstdhl
                 std::string trace( void ) const;
 
                 void setTrace( const std::string& trace );
+
+                WorkspaceFolders workspaceFolders( void ) const;
+
+                u1 hasWorkspaceFolders( void ) const;
+
+                void addWorkspaceFolder( WorkspaceFolder folder );
 
                 static void validate( const Data& data );
             };
@@ -1435,22 +1457,6 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
-
-            class WorkspaceFolder : public Data
-            {
-              public:
-                WorkspaceFolder( const std::string& uri, const std::string& name );
-
-                WorkspaceFolder( const Data& data );
-
-                std::string uri( void ) const;
-
-                std::string name( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using WorkspaceFolders = std::vector< WorkspaceFolder >;
 
             class WorkspaceFoldersResult : public Data
             {

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1122,6 +1122,20 @@ namespace libstdhl
                 Log = 4
             };
 
+            class CancelParams : public Data
+            {
+              public:
+                CancelParams( const Data& data );
+
+                CancelParams( const std::size_t& id );
+
+                CancelParams( const std::string& id );
+
+                std::string id( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class ShowMessageParams : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2329,14 +2329,18 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            using LocationLinks = std::vector< LocationLink >;
+
             class TypeDefinitionResult : public Data
             {
               public:
                 TypeDefinitionResult( const Data& data );
 
-                TypeDefinitionResult( const Locations locations );
+                TypeDefinitionResult( const Locations& locations );
 
-                TypeDefinitionResult( const Location location );
+                TypeDefinitionResult( const LocationLinks& locationLinks );
+
+                TypeDefinitionResult( const Location& location );
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -433,6 +433,46 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            class CreateFileOptions : public Data
+            {
+              public:
+                CreateFileOptions( const Data& data );
+
+                CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists );
+
+                u1 hasOverwrite( void ) const;
+
+                u1 overwrite( void ) const;
+
+                void setOverwrite( const u1 overwrite );
+
+                u1 hasIgnoreIfExists( void ) const;
+
+                u1 ignoreIfExists( void ) const;
+
+                void setIgnoreIfExists( const u1 ignoreIfExists );
+
+                static void validate( const Data& data );
+            };
+
+            class CreateFile : public Data
+            {
+              public:
+                CreateFile( const Data& data );
+
+                CreateFile( const DocumentUri& uri );
+
+                DocumentUri uri( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const CreateFileOptions& options );
+
+                CreateFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class TextDocumentItem : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -464,6 +464,8 @@ namespace libstdhl
 
                 DocumentUri uri( void ) const;
 
+                std::string kind( void ) const;
+
                 u1 hasOptions( void ) const;
 
                 void setOptions( const CreateFileOptions& options );

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1109,6 +1109,40 @@ namespace libstdhl
 
             using FoldingRangeProvider = ColorProvider;
 
+            class Workspace : public Data
+            {
+              public:
+                Workspace( const Data& data );
+
+                static void validate( const Data& data );
+
+                class WorkspaceFolders : public Data
+                {
+                  public:
+                    WorkspaceFolders( const Data& data );
+
+                    u1 supported( void ) const;
+
+                    u1 hasSupported( void ) const;
+
+                    void setSupported( const u1 supported );
+
+                    void setChangeNotifications( const std::string& changeNotifications );
+
+                    void setChangeNotifications( const u1 changeNotifications );
+
+                    u1 hasChangeNotifications( void ) const;
+
+                    std::string changeNotifications( void ) const;
+
+                    static void validate( const Data& data );
+                };
+                WorkspaceFolders workspaceFolders( void ) const;
+
+                u1 hasWorkspaceFolders( void ) const;
+
+                void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
+            };
             class ServerCapabilities : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2287,7 +2287,17 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
-            using SignatureHelpResult = SignatureHelp;
+            class SignatureHelpResult : public Data
+            {
+              public:
+                SignatureHelpResult( void );
+
+                SignatureHelpResult( const Data& data );
+
+                SignatureHelpResult( const SignatureHelp& signature );
+
+                static void validate( const Data& data );
+            };
 
             using TypeDefinitionParams = TextDocumentPositionParams;
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1288,6 +1288,12 @@ namespace libstdhl
 
                 void setExperimental( const Data& experimental );
 
+                u1 hasWorkspace( void ) const;
+
+                void setWorkspace( const Workspace& workspace );
+
+                Workspace workspace( void ) const;
+
                 static void validate( const Data& data );
             };
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1037,6 +1037,47 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+            class StaticRegistrationOptions : public Data
+            {
+              public:
+                StaticRegistrationOptions( const Data& data );
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
+
+            class TextDocumentRegistrationOptions : public Data
+            {
+              public:
+                TextDocumentRegistrationOptions( const Data& data );
+
+                TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
+
+                DocumentSelector documentSelector( void ) const;
+
+                static void validate( const Data& data );
+            };
+
+            class TypeDefinitionProvider : Data
+            {
+              public:
+                TypeDefinitionProvider( const Data& data );
+
+                DocumentSelector documentSelector( void ) const;
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
 
             class ServerCapabilities : public Data
             {
@@ -1366,18 +1407,6 @@ namespace libstdhl
                 RegistrationParams( const Registrations& registrations );
 
                 Registrations registrations( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentRegistrationOptions : public Data
-            {
-              public:
-                TextDocumentRegistrationOptions( const Data& data );
-
-                TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
-
-                DocumentSelector documentSelector( void ) const;
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1081,6 +1081,34 @@ namespace libstdhl
 
             using ImplementationProvider = TypeDefinitionProvider;
 
+            class ColorProviderOptions : public Data
+            {
+              public:
+                ColorProviderOptions( const Data& data );
+
+                static void validate( const Data& data );
+            };
+
+            using FoldingRangeProviderOptions = ColorProviderOptions;
+
+            class ColorProvider : public Data
+            {
+              public:
+                ColorProvider( const Data& data );
+
+                DocumentSelector documentSelector( void ) const;
+
+                u1 hasId( void ) const;
+
+                std::string id( void ) const;
+
+                void setId( std::string id );
+
+                static void validate( const Data& data );
+            };
+
+            using FoldingRangeProvider = ColorProvider;
+
             class ServerCapabilities : public Data
             {
               public:
@@ -1200,6 +1228,18 @@ namespace libstdhl
                 DocumentLinkOptions documentLinkProvider( void ) const;
 
                 void setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider );
+
+                u1 hasColorProvider( void ) const;
+
+                ColorProvider colorProvider( void ) const;
+
+                void setColorProvider( const ColorProvider& colorProvider );
+
+                u1 hasFoldingRangeProvider( void ) const;
+
+                FoldingRangeProvider foldingRangeProvider( void ) const;
+
+                void setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider );
 
                 u1 hasExecuteCommandProvider( void ) const;
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -1063,7 +1063,7 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
-            class TypeDefinitionProvider : Data
+            class TypeDefinitionProvider : public Data
             {
               public:
                 TypeDefinitionProvider( const Data& data );
@@ -1078,6 +1078,8 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
+
+            using ImplementationProvider = TypeDefinitionProvider;
 
             class ServerCapabilities : public Data
             {
@@ -1117,6 +1119,20 @@ namespace libstdhl
                 u1 definitionProvider( void ) const;
 
                 void setDefinitionProvider( const u1 definitionProvider );
+
+                u1 hasTypeDefinitionProvider( void ) const;
+
+                TypeDefinitionProvider typeDefinitionProvider( void ) const;
+
+                void setTypeDefinitionProvider(
+                    const TypeDefinitionProvider& typeDefinitionProvider );
+
+                u1 hasImplementationProvider( void ) const;
+
+                ImplementationProvider implementationProvider( void ) const;
+
+                void setImplementationProvider(
+                    const ImplementationProvider& implementationProvider );
 
                 u1 hasReferencesProvider( void ) const;
 

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2899,7 +2899,7 @@ namespace libstdhl
 
                 Position position( void ) const;
 
-                std::string character( void ) const; 
+                std::string character( void ) const;
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -499,6 +499,26 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            class DeleteFileOptions : public Data
+            {
+              public:
+                DeleteFileOptions( const Data& data );
+
+                u1 hasRecursive( void ) const;
+
+                u1 recursive( void ) const;
+
+                void setRecursive( const u1 recursive );
+
+                u1 hasIgnoreIfExists( void ) const;
+
+                u1 ignoreIfExists( void ) const;
+
+                void setIgnoreIfExists( const u1 ignoreIfExists );
+
+                static void validate( const Data& data );
+            };
+
             class TextDocumentItem : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -519,6 +519,26 @@ namespace libstdhl
                 static void validate( const Data& data );
             };
 
+            class DeleteFile : public Data
+            {
+              public:
+                DeleteFile( const Data& data );
+
+                DeleteFile( const DocumentUri& uri );
+
+                DocumentUri uri( void ) const;
+
+                std::string kind( void ) const;
+
+                u1 hasOptions( void ) const;
+
+                void setOptions( const DeleteFileOptions& options );
+
+                DeleteFileOptions options( void ) const;
+
+                static void validate( const Data& data );
+            };
+
             class TextDocumentItem : public Data
             {
               public:

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -66,580 +66,644 @@ namespace libstdhl
 
             using DocumentUri = libstdhl::Standard::RFC3986::URI;
 
-            namespace Content
-            {
-                u1 hasProperty( const Data& data, const std::string& field );
+        }
 
-                void validateTypeIsObject( const std::string& context, const Data& data );
+        enum class ErrorCode : i32
+        {
+            // defined by JSON RPC
+            ParseError = -32700,
+            InvalidRequest = -32600,
+            MethodNotFound = -32601,
+            InvalidParams = -32602,
+            InternalError = -32603,
+            serverErrorStart = -32099,
+            serverErrorEnd = -32000,
+            ServerNotInitialized = -32002,
+            UnknownErrorCode = -32001,
 
-                void validateTypeIsString( const std::string& context, const Data& data );
+            // defined by LSP
+            RequestCancelled = -32800,
 
-                void validateTypeIsArray( const std::string& context, const Data& data );
+        };
 
-                void validatePropertyIs(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required,
-                    const std::function< u1( const Data& property ) >& condition );
+        class ResponseError final : public Data
+        {
+          public:
+            ResponseError( const Data& data );
 
-                void validatePropertyIsObject(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            ResponseError( const ErrorCode code, const std::string& message );
 
-                void validatePropertyIsArray(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            ErrorCode code( void ) const;
 
-                void validatePropertyIsString(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            std::string message( void ) const;
 
-                void validatePropertyIsNumber(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            u1 hasData( void ) const;
 
-                void validatePropertyIsNumberOrNull(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            Data data( void ) const;
 
-                void validatePropertyIsBoolean(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            void setData( const Data& data );
 
-                void validatePropertyIsUuid(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            static void validate( const Data& data );
+        };
 
-                void validatePropertyIsUri(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+        namespace TextDocument
+        {
+            constexpr const std::array< const char*, 3 > EOL = { { "\n", "\r\n", "\r" } };
+        }
 
-                void validatePropertyIsUriOrNull(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+        class Position : public Data
+        {
+          public:
+            Position( const Data& data );
 
-                template < class T >
-                void validatePropertyIs(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required )
-                {
-                    validatePropertyIs(
-                        context, data, field, required, []( const Data& property ) -> u1 {
-                            T::validate( property );
-                            return true;
-                        } );
-                };
+            Position( const std::size_t line, const std::size_t character );
 
-                template < class T >
-                void validatePropertyIsArrayOf(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required )
-                {
-                    validatePropertyIsArray( context, data, field, required );
-                    if( hasProperty( data, field ) )
-                    {
-                        for( auto element : data[ field ] )
-                        {
-                            T::validate( element );
-                        }
-                    }
-                };
+            std::size_t line( void ) const;
 
-                void validatePropertyIsArrayOfString(
-                    const std::string& context,
-                    const Data& data,
-                    const std::string& field,
-                    const u1 required );
+            std::size_t character( void ) const;
 
-                template < class T >
-                void validateTypeIsArrayOf( const std::string& context, const Data& data )
-                {
-                    validateTypeIsArray( context, data );
-                    for( auto element : data )
-                    {
-                        T::validate( element );
-                    }
-                };
-                template < class T, class U >
-                void validateTypeIsMixedArrayOf( const std::string& context, const Data& data )
-                {
-                    Content::validateTypeIsArray( context, data );
-                    for( auto element : data )
-                    {
-                        try
-                        {
-                            T::validate( element );
-                        }
-                        catch( std::invalid_argument a )
-                        {
-                            U::validate( element );
-                        }
-                    }
-                };
-                template < class T, class U >
-                void validateTypeIsArrayOf( const std::string& context, const Data& data )
-                {
-                    try
-                    {
-                        validateTypeIsArrayOf< T >( context, data );
-                    }
-                    catch( std::invalid_argument a )
-                    {
-                        validateTypeIsArrayOf< U >( context, data );
-                    }
-                };
-            }
+            static void validate( const Data& data );
+        };
 
-            enum class ErrorCode : i32
-            {
-                // defined by JSON RPC
-                ParseError = -32700,
-                InvalidRequest = -32600,
-                MethodNotFound = -32601,
-                InvalidParams = -32602,
-                InternalError = -32603,
-                serverErrorStart = -32099,
-                serverErrorEnd = -32000,
-                ServerNotInitialized = -32002,
-                UnknownErrorCode = -32001,
+        class Range : public Data
+        {
+          public:
+            Range( const Data& data );
 
-                // defined by LSP
-                RequestCancelled = -32800,
+            Range( const Position& start, const Position& end );
 
-            };
+            Position start( void ) const;
 
-            class ResponseError final : public Data
+            Position end( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class Location : public Data
+        {
+          public:
+            Location( const Data& data );
+
+            Location( const DocumentUri& uri, const Range& range );
+
+            DocumentUri uri( void ) const;
+
+            Range range( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        enum class DiagnosticSeverity : std::size_t
+        {
+            Error = 1,
+            Warning = 2,
+            Information = 3,
+            Hint = 4,
+        };
+
+        class DiagnosticRelatedInformation : public Data
+        {
+          public:
+            DiagnosticRelatedInformation( const Data& data );
+
+            DiagnosticRelatedInformation( const Location& location, const std::string& message );
+
+            Location location( void ) const;
+
+            std::string message( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class Diagnostic : public Data
+        {
+          public:
+            Diagnostic( const Data& data );
+
+            Diagnostic( const Range& range, const std::string& message );
+
+            Range range( void ) const;
+
+            std::string message( void ) const;
+
+            u1 hasSeverity( void ) const;
+
+            DiagnosticSeverity severity( void ) const;
+
+            void setSeverity( const DiagnosticSeverity& severity );
+
+            u1 hasCode( void ) const;
+
+            std::string code( void ) const;
+
+            void setCode( const std::string& code );
+
+            void setCode( const std::size_t code );
+
+            u1 hasSource( void ) const;
+
+            std::string source( void ) const;
+
+            void setSource( const std::string& source );
+
+            static void validate( const Data& data );
+        };
+
+        class Command : public Data
+        {
+          public:
+            Command( const Data& data );
+
+            Command( const std::string& title, const std::string& command );
+
+            std::string title( void ) const;
+
+            std::string command( void ) const;
+
+            u1 hasArguments( void ) const;
+
+            Data arguments( void ) const;
+
+            void addArgument( const Data& argument );
+
+            static void validate( const Data& data );
+        };
+
+        class TextEdit : public Data
+        {
+          public:
+            TextEdit( const Data& data );
+
+            TextEdit( const Range& range, const std::string& newText );
+
+            Range range( void ) const;
+
+            std::string newText( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentIdentifier : public Data
+        {
+          public:
+            TextDocumentIdentifier( const Data& data );
+
+            TextDocumentIdentifier( const DocumentUri& uri );
+
+            DocumentUri uri( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class VersionedTextDocumentIdentifier : public TextDocumentIdentifier
+        {
+          public:
+            VersionedTextDocumentIdentifier( const Data& data );
+
+            VersionedTextDocumentIdentifier( const DocumentUri& uri, const std::size_t version );
+
+            std::size_t version( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentEdit : public Data
+        {
+          public:
+            TextDocumentEdit( const Data& data );
+
+            TextDocumentEdit(
+                const VersionedTextDocumentIdentifier& textDocument,
+                const std::vector< TextEdit >& edits );
+
+            VersionedTextDocumentIdentifier textDocument( void ) const;
+
+            Data edits( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class WorkspaceEdit : public Data
+        {
+          public:
+            WorkspaceEdit( const Data& data );
+
+            WorkspaceEdit( void );
+
+            // changes interface omitted!
+
+            u1 hasDocumentChanges( void ) const;
+
+            Data documentChanges( void ) const;
+
+            void addDocumentChange( const TextDocumentEdit& documentChange );
+
+            static void validate( const Data& data );
+        };
+
+        class CreateFileOptions : public Data
+        {
+          public:
+            CreateFileOptions( const Data& data );
+
+            CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists );
+
+            u1 hasOverwrite( void ) const;
+
+            u1 overwrite( void ) const;
+
+            void setOverwrite( const u1 overwrite );
+
+            u1 hasIgnoreIfExists( void ) const;
+
+            u1 ignoreIfExists( void ) const;
+
+            void setIgnoreIfExists( const u1 ignoreIfExists );
+
+            static void validate( const Data& data );
+        };
+
+        class CreateFile : public Data
+        {
+          public:
+            CreateFile( const Data& data );
+
+            CreateFile( const DocumentUri& uri );
+
+            DocumentUri uri( void ) const;
+
+            std::string kind( void ) const;
+
+            u1 hasOptions( void ) const;
+
+            void setOptions( const CreateFileOptions& options );
+
+            CreateFileOptions options( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using RenameFileOptions = CreateFileOptions;
+
+        class RenameFile : public Data
+        {
+          public:
+            RenameFile( const Data& data );
+
+            RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri );
+
+            DocumentUri newUri( void ) const;
+
+            DocumentUri oldUri( void ) const;
+
+            std::string kind( void ) const;
+
+            u1 hasOptions( void ) const;
+
+            void setOptions( const CreateFileOptions& options );
+
+            CreateFileOptions options( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DeleteFileOptions : public Data
+        {
+          public:
+            DeleteFileOptions( const Data& data );
+
+            u1 hasRecursive( void ) const;
+
+            u1 recursive( void ) const;
+
+            void setRecursive( const u1 recursive );
+
+            u1 hasIgnoreIfExists( void ) const;
+
+            u1 ignoreIfExists( void ) const;
+
+            void setIgnoreIfExists( const u1 ignoreIfExists );
+
+            static void validate( const Data& data );
+        };
+
+        class DeleteFile : public Data
+        {
+          public:
+            DeleteFile( const Data& data );
+
+            DeleteFile( const DocumentUri& uri );
+
+            DocumentUri uri( void ) const;
+
+            std::string kind( void ) const;
+
+            u1 hasOptions( void ) const;
+
+            void setOptions( const DeleteFileOptions& options );
+
+            DeleteFileOptions options( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentItem : public Data
+        {
+          public:
+            TextDocumentItem( const Data& data );
+
+            TextDocumentItem(
+                const DocumentUri& uri,
+                const std::string& languageId,
+                const std::size_t version,
+                const std::string& text );
+
+            DocumentUri uri( void ) const;
+
+            std::string languageId( void ) const;
+
+            std::size_t version( void ) const;
+
+            std::string text( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentPositionParams : public Data
+        {
+          public:
+            TextDocumentPositionParams( const Data& data );
+
+            TextDocumentPositionParams(
+                const TextDocumentIdentifier& textDocument, const Position& position );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            Position position( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentFilter : public Data
+        {
+          public:
+            DocumentFilter( const Data& data );
+
+            DocumentFilter( void );
+
+            u1 hasLanguage( void ) const;
+
+            std::string language( void ) const;
+
+            void setLanguage( const std::string& language );
+
+            u1 hasScheme( void ) const;
+
+            std::string scheme( void ) const;
+
+            void setScheme( const std::string& scheme );
+
+            u1 hasPattern( void ) const;
+
+            std::string pattern( void ) const;
+
+            void setPattern( const std::string& pattern );
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentSelector : public Data
+        {
+          public:
+            DocumentSelector( const Data& data );
+
+            DocumentSelector( const std::vector< DocumentFilter >& documentFilters );
+
+            static void validate( const Data& data );
+        };
+
+        //
+        //
+        // Actual Protocol
+        //
+
+        class DynamicRegistration : public Data
+        {
+          public:
+            DynamicRegistration( const Data& data );
+
+            DynamicRegistration( void );
+
+            u1 hasDynamicRegistration( void ) const;
+
+            u1 dynamicRegistration( void ) const;
+
+            void setDynamicRegistration( const u1 dynamicRegistration );
+
+            static void validate( const Data& data );
+        };
+
+        class WorkspaceClientCapabilities : public Data
+        {
+          public:
+            WorkspaceClientCapabilities( const Data& data );
+
+            WorkspaceClientCapabilities( void );
+
+            u1 hasApplyEdit( void ) const;
+
+            u1 applyEdit( void ) const;
+
+            void setApplyEdit( const u1 applyEdit );
+
+            u1 hasWorkspaceEdit( void ) const;
+
+            WorkspaceEdit workspaceEdit( void ) const;
+
+            void setWorkspaceEdit( const WorkspaceEdit& workspaceEdit );
+
+            u1 hasDidChangeConfiguration( void ) const;
+
+            DynamicRegistration didChangeConfiguration( void ) const;
+
+            void setDidChangeConfiguration( const DynamicRegistration& didChangeConfiguration );
+
+            u1 hasDidChangeWatchedFiles( void ) const;
+
+            DynamicRegistration didChangeWatchedFiles( void ) const;
+
+            void didChangeWatchedFiles( const DynamicRegistration& didChangeWatchedFiles );
+
+            u1 hasSymbol( void ) const;
+
+            DynamicRegistration symbol( void ) const;
+
+            void setSymbol( const DynamicRegistration& symbol );
+
+            u1 hasExecuteCommand( void ) const;
+
+            DynamicRegistration executeCommand( void ) const;
+
+            void executeCommand( const DynamicRegistration& executeCommand );
+
+            u1 hasWorkspaceFolders( void ) const;
+
+            void setWorkspaceFolders( const u1 workspaceFolders );
+
+            u1 workspaceFolders( void ) const;
+
+            u1 hasConfiguration( void ) const;
+
+            void setConfiguration( const u1 configuration );
+
+            u1 configuration( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class Synchronization : public Data
+        {
+          public:
+            Synchronization( const Data& data );
+
+            Synchronization( void );
+
+            u1 hasDynamicRegistration( void ) const;
+
+            u1 dynamicRegistration( void ) const;
+
+            void setDynamicRegistration( const u1 dynamicRegistration );
+
+            u1 hasWillSave( void ) const;
+
+            u1 willSave( void ) const;
+
+            void setWillSave( const u1 willSave );
+
+            u1 hasWillSaveWaitUntil( void ) const;
+
+            u1 willSaveWaitUntil( void ) const;
+
+            void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
+
+            u1 hasDidSave( void ) const;
+
+            u1 didSave( void ) const;
+
+            void setDidSave( const u1 didSave );
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentClientCapabilities : public Data
+        {
+            class CompletionItem;
+            class Completion;
+
+          public:
+            TextDocumentClientCapabilities( const Data& data );
+
+            TextDocumentClientCapabilities( void );
+
+            u1 hasSynchronization( void ) const;
+
+            Synchronization synchronization( void ) const;
+
+            void setSynchronization( const Synchronization& synchronization );
+
+            u1 hasCompletion( void ) const;
+
+            Completion completion( void ) const;
+
+            void setCompletion( const Completion& completion );
+
+            u1 hasHover( void ) const;
+
+            DynamicRegistration hover( void ) const;
+
+            void setHover( const DynamicRegistration& hover );
+
+            u1 hasSignatureHelp( void ) const;
+
+            DynamicRegistration signatureHelp( void ) const;
+
+            void setSignatureHelp( const DynamicRegistration& signatureHelp );
+
+            u1 hasReferences( void ) const;
+
+            DynamicRegistration references( void ) const;
+
+            void setReferences( const DynamicRegistration& references );
+
+            u1 hasDocumentHighlight( void ) const;
+
+            DynamicRegistration documentHighlight( void ) const;
+
+            void setDocumentHighlight( const DynamicRegistration& documentHighlight );
+
+            u1 hasDocumentSymbol( void ) const;
+
+            DynamicRegistration documentSymbol( void ) const;
+
+            void setDocumentSymbol( const DynamicRegistration& documentSymbol );
+
+            u1 hasFormatting( void ) const;
+
+            DynamicRegistration formatting( void ) const;
+
+            void setFormatting( const DynamicRegistration& formatting );
+
+            u1 hasRangeFormatting( void ) const;
+
+            DynamicRegistration rangeFormatting( void ) const;
+
+            void setRangeFormatting( const DynamicRegistration& rangeFormatting );
+
+            u1 hasOnTypeFormatting( void ) const;
+
+            DynamicRegistration onTypeFormatting( void ) const;
+
+            void setOnTypeFormatting( const DynamicRegistration& onTypeFormatting );
+
+            u1 hasDefinition( void ) const;
+
+            DynamicRegistration definition( void ) const;
+
+            void setDefinition( const DynamicRegistration& definition );
+
+            u1 hasCodeAction( void ) const;
+
+            DynamicRegistration codeAction( void ) const;
+
+            void setCodeAction( const DynamicRegistration& codeAction );
+
+            u1 hasCodeLens( void ) const;
+
+            DynamicRegistration codeLens( void ) const;
+
+            void setCodeLens( const DynamicRegistration& codeLens );
+
+            u1 hasDocumentLink( void ) const;
+
+            DynamicRegistration documentLink( void ) const;
+
+            void setDocumentLink( const DynamicRegistration& documentLink );
+
+            u1 hasRename( void ) const;
+
+            DynamicRegistration rename( void ) const;
+
+            void setRename( const DynamicRegistration& rename );
+
+            static void validate( const Data& data );
+
+          private:
+            class Completion : public Data
             {
               public:
-                ResponseError( const Data& data );
+                Completion( const Data& data );
 
-                ResponseError( const ErrorCode code, const std::string& message );
-
-                ErrorCode code( void ) const;
-
-                std::string message( void ) const;
-
-                u1 hasData( void ) const;
-
-                Data data( void ) const;
-
-                void setData( const Data& data );
-
-                static void validate( const Data& data );
-            };
-
-            namespace TextDocument
-            {
-                constexpr const std::array< const char*, 3 > EOL = { { "\n", "\r\n", "\r" } };
-            }
-
-            class Position : public Data
-            {
-              public:
-                Position( const Data& data );
-
-                Position( const std::size_t line, const std::size_t character );
-
-                std::size_t line( void ) const;
-
-                std::size_t character( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class Range : public Data
-            {
-              public:
-                Range( const Data& data );
-
-                Range( const Position& start, const Position& end );
-
-                Position start( void ) const;
-
-                Position end( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class Location : public Data
-            {
-              public:
-                Location( const Data& data );
-
-                Location( const DocumentUri& uri, const Range& range );
-
-                DocumentUri uri( void ) const;
-
-                Range range( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class DiagnosticSeverity : std::size_t
-            {
-                Error = 1,
-                Warning = 2,
-                Information = 3,
-                Hint = 4,
-            };
-
-            class DiagnosticRelatedInformation : public Data
-            {
-              public:
-                DiagnosticRelatedInformation( const Data& data );
-
-                DiagnosticRelatedInformation(
-                    const Location& location, const std::string& message );
-
-                Location location( void ) const;
-
-                std::string message( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class Diagnostic : public Data
-            {
-              public:
-                Diagnostic( const Data& data );
-
-                Diagnostic( const Range& range, const std::string& message );
-
-                Range range( void ) const;
-
-                std::string message( void ) const;
-
-                u1 hasSeverity( void ) const;
-
-                DiagnosticSeverity severity( void ) const;
-
-                void setSeverity( const DiagnosticSeverity& severity );
-
-                u1 hasCode( void ) const;
-
-                std::string code( void ) const;
-
-                void setCode( const std::string& code );
-
-                void setCode( const std::size_t code );
-
-                u1 hasSource( void ) const;
-
-                std::string source( void ) const;
-
-                void setSource( const std::string& source );
-
-                static void validate( const Data& data );
-            };
-
-            class Command : public Data
-            {
-              public:
-                Command( const Data& data );
-
-                Command( const std::string& title, const std::string& command );
-
-                std::string title( void ) const;
-
-                std::string command( void ) const;
-
-                u1 hasArguments( void ) const;
-
-                Data arguments( void ) const;
-
-                void addArgument( const Data& argument );
-
-                static void validate( const Data& data );
-            };
-
-            class TextEdit : public Data
-            {
-              public:
-                TextEdit( const Data& data );
-
-                TextEdit( const Range& range, const std::string& newText );
-
-                Range range( void ) const;
-
-                std::string newText( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentIdentifier : public Data
-            {
-              public:
-                TextDocumentIdentifier( const Data& data );
-
-                TextDocumentIdentifier( const DocumentUri& uri );
-
-                DocumentUri uri( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class VersionedTextDocumentIdentifier : public TextDocumentIdentifier
-            {
-              public:
-                VersionedTextDocumentIdentifier( const Data& data );
-
-                VersionedTextDocumentIdentifier(
-                    const DocumentUri& uri, const std::size_t version );
-
-                std::size_t version( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentEdit : public Data
-            {
-              public:
-                TextDocumentEdit( const Data& data );
-
-                TextDocumentEdit(
-                    const VersionedTextDocumentIdentifier& textDocument,
-                    const std::vector< TextEdit >& edits );
-
-                VersionedTextDocumentIdentifier textDocument( void ) const;
-
-                Data edits( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceEdit : public Data
-            {
-              public:
-                WorkspaceEdit( const Data& data );
-
-                WorkspaceEdit( void );
-
-                // changes interface omitted!
-
-                u1 hasDocumentChanges( void ) const;
-
-                Data documentChanges( void ) const;
-
-                void addDocumentChange( const TextDocumentEdit& documentChange );
-
-                static void validate( const Data& data );
-            };
-
-            class CreateFileOptions : public Data
-            {
-              public:
-                CreateFileOptions( const Data& data );
-
-                CreateFileOptions( const u1 overwrite, const u1 ignoreIfExists );
-
-                u1 hasOverwrite( void ) const;
-
-                u1 overwrite( void ) const;
-
-                void setOverwrite( const u1 overwrite );
-
-                u1 hasIgnoreIfExists( void ) const;
-
-                u1 ignoreIfExists( void ) const;
-
-                void setIgnoreIfExists( const u1 ignoreIfExists );
-
-                static void validate( const Data& data );
-            };
-
-            class CreateFile : public Data
-            {
-              public:
-                CreateFile( const Data& data );
-
-                CreateFile( const DocumentUri& uri );
-
-                DocumentUri uri( void ) const;
-
-                std::string kind( void ) const;
-
-                u1 hasOptions( void ) const;
-
-                void setOptions( const CreateFileOptions& options );
-
-                CreateFileOptions options( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using RenameFileOptions = CreateFileOptions;
-
-            class RenameFile : public Data
-            {
-              public:
-                RenameFile( const Data& data );
-
-                RenameFile( const DocumentUri& oldUri, const DocumentUri& newUri );
-
-                DocumentUri newUri( void ) const;
-
-                DocumentUri oldUri( void ) const;
-
-                std::string kind( void ) const;
-
-                u1 hasOptions( void ) const;
-
-                void setOptions( const CreateFileOptions& options );
-
-                CreateFileOptions options( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class DeleteFileOptions : public Data
-            {
-              public:
-                DeleteFileOptions( const Data& data );
-
-                u1 hasRecursive( void ) const;
-
-                u1 recursive( void ) const;
-
-                void setRecursive( const u1 recursive );
-
-                u1 hasIgnoreIfExists( void ) const;
-
-                u1 ignoreIfExists( void ) const;
-
-                void setIgnoreIfExists( const u1 ignoreIfExists );
-
-                static void validate( const Data& data );
-            };
-
-            class DeleteFile : public Data
-            {
-              public:
-                DeleteFile( const Data& data );
-
-                DeleteFile( const DocumentUri& uri );
-
-                DocumentUri uri( void ) const;
-
-                std::string kind( void ) const;
-
-                u1 hasOptions( void ) const;
-
-                void setOptions( const DeleteFileOptions& options );
-
-                DeleteFileOptions options( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentItem : public Data
-            {
-              public:
-                TextDocumentItem( const Data& data );
-
-                TextDocumentItem(
-                    const DocumentUri& uri,
-                    const std::string& languageId,
-                    const std::size_t version,
-                    const std::string& text );
-
-                DocumentUri uri( void ) const;
-
-                std::string languageId( void ) const;
-
-                std::size_t version( void ) const;
-
-                std::string text( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentPositionParams : public Data
-            {
-              public:
-                TextDocumentPositionParams( const Data& data );
-
-                TextDocumentPositionParams(
-                    const TextDocumentIdentifier& textDocument, const Position& position );
-
-                TextDocumentIdentifier textDocument( void ) const;
-
-                Position position( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class DocumentFilter : public Data
-            {
-              public:
-                DocumentFilter( const Data& data );
-
-                DocumentFilter( void );
-
-                u1 hasLanguage( void ) const;
-
-                std::string language( void ) const;
-
-                void setLanguage( const std::string& language );
-
-                u1 hasScheme( void ) const;
-
-                std::string scheme( void ) const;
-
-                void setScheme( const std::string& scheme );
-
-                u1 hasPattern( void ) const;
-
-                std::string pattern( void ) const;
-
-                void setPattern( const std::string& pattern );
-
-                static void validate( const Data& data );
-            };
-
-            class DocumentSelector : public Data
-            {
-              public:
-                DocumentSelector( const Data& data );
-
-                DocumentSelector( const std::vector< DocumentFilter >& documentFilters );
-
-                static void validate( const Data& data );
-            };
-
-            //
-            //
-            // Actual Protocol
-            //
-
-            class DynamicRegistration : public Data
-            {
-              public:
-                DynamicRegistration( const Data& data );
-
-                DynamicRegistration( void );
+                Completion( void );
 
                 u1 hasDynamicRegistration( void ) const;
 
@@ -647,2779 +711,2372 @@ namespace libstdhl
 
                 void setDynamicRegistration( const u1 dynamicRegistration );
 
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceClientCapabilities : public Data
-            {
-              public:
-                WorkspaceClientCapabilities( const Data& data );
-
-                WorkspaceClientCapabilities( void );
-
-                u1 hasApplyEdit( void ) const;
-
-                u1 applyEdit( void ) const;
-
-                void setApplyEdit( const u1 applyEdit );
-
-                u1 hasWorkspaceEdit( void ) const;
-
-                WorkspaceEdit workspaceEdit( void ) const;
-
-                void setWorkspaceEdit( const WorkspaceEdit& workspaceEdit );
-
-                u1 hasDidChangeConfiguration( void ) const;
-
-                DynamicRegistration didChangeConfiguration( void ) const;
-
-                void setDidChangeConfiguration( const DynamicRegistration& didChangeConfiguration );
-
-                u1 hasDidChangeWatchedFiles( void ) const;
-
-                DynamicRegistration didChangeWatchedFiles( void ) const;
-
-                void didChangeWatchedFiles( const DynamicRegistration& didChangeWatchedFiles );
-
-                u1 hasSymbol( void ) const;
-
-                DynamicRegistration symbol( void ) const;
-
-                void setSymbol( const DynamicRegistration& symbol );
-
-                u1 hasExecuteCommand( void ) const;
-
-                DynamicRegistration executeCommand( void ) const;
-
-                void executeCommand( const DynamicRegistration& executeCommand );
-
-                u1 hasWorkspaceFolders( void ) const;
-
-                void setWorkspaceFolders( const u1 workspaceFolders );
-
-                u1 workspaceFolders( void ) const;
-
-                u1 hasConfiguration( void ) const;
-
-                void setConfiguration( const u1 configuration );
-
-                u1 configuration( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class Synchronization : public Data
-            {
-              public:
-                Synchronization( const Data& data );
-
-                Synchronization( void );
-
-                u1 hasDynamicRegistration( void ) const;
-
-                u1 dynamicRegistration( void ) const;
-
-                void setDynamicRegistration( const u1 dynamicRegistration );
-
-                u1 hasWillSave( void ) const;
-
-                u1 willSave( void ) const;
-
-                void setWillSave( const u1 willSave );
-
-                u1 hasWillSaveWaitUntil( void ) const;
-
-                u1 willSaveWaitUntil( void ) const;
-
-                void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
-
-                u1 hasDidSave( void ) const;
-
-                u1 didSave( void ) const;
-
-                void setDidSave( const u1 didSave );
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentClientCapabilities : public Data
-            {
-                class CompletionItem;
-                class Completion;
-
-              public:
-                TextDocumentClientCapabilities( const Data& data );
-
-                TextDocumentClientCapabilities( void );
-
-                u1 hasSynchronization( void ) const;
-
-                Synchronization synchronization( void ) const;
-
-                void setSynchronization( const Synchronization& synchronization );
-
-                u1 hasCompletion( void ) const;
-
-                Completion completion( void ) const;
-
-                void setCompletion( const Completion& completion );
-
-                u1 hasHover( void ) const;
-
-                DynamicRegistration hover( void ) const;
-
-                void setHover( const DynamicRegistration& hover );
-
-                u1 hasSignatureHelp( void ) const;
-
-                DynamicRegistration signatureHelp( void ) const;
-
-                void setSignatureHelp( const DynamicRegistration& signatureHelp );
-
-                u1 hasReferences( void ) const;
-
-                DynamicRegistration references( void ) const;
-
-                void setReferences( const DynamicRegistration& references );
-
-                u1 hasDocumentHighlight( void ) const;
-
-                DynamicRegistration documentHighlight( void ) const;
-
-                void setDocumentHighlight( const DynamicRegistration& documentHighlight );
-
-                u1 hasDocumentSymbol( void ) const;
-
-                DynamicRegistration documentSymbol( void ) const;
-
-                void setDocumentSymbol( const DynamicRegistration& documentSymbol );
-
-                u1 hasFormatting( void ) const;
-
-                DynamicRegistration formatting( void ) const;
-
-                void setFormatting( const DynamicRegistration& formatting );
-
-                u1 hasRangeFormatting( void ) const;
-
-                DynamicRegistration rangeFormatting( void ) const;
-
-                void setRangeFormatting( const DynamicRegistration& rangeFormatting );
-
-                u1 hasOnTypeFormatting( void ) const;
-
-                DynamicRegistration onTypeFormatting( void ) const;
-
-                void setOnTypeFormatting( const DynamicRegistration& onTypeFormatting );
-
-                u1 hasDefinition( void ) const;
-
-                DynamicRegistration definition( void ) const;
-
-                void setDefinition( const DynamicRegistration& definition );
-
-                u1 hasCodeAction( void ) const;
-
-                DynamicRegistration codeAction( void ) const;
-
-                void setCodeAction( const DynamicRegistration& codeAction );
-
-                u1 hasCodeLens( void ) const;
-
-                DynamicRegistration codeLens( void ) const;
-
-                void setCodeLens( const DynamicRegistration& codeLens );
-
-                u1 hasDocumentLink( void ) const;
-
-                DynamicRegistration documentLink( void ) const;
-
-                void setDocumentLink( const DynamicRegistration& documentLink );
-
-                u1 hasRename( void ) const;
-
-                DynamicRegistration rename( void ) const;
-
-                void setRename( const DynamicRegistration& rename );
-
-                static void validate( const Data& data );
-
-              private:
-                class Completion : public Data
-                {
-                  public:
-                    Completion( const Data& data );
-
-                    Completion( void );
-
-                    u1 hasDynamicRegistration( void ) const;
-
-                    u1 dynamicRegistration( void ) const;
-
-                    void setDynamicRegistration( const u1 dynamicRegistration );
-
-                    u1 hasCompletionItem( void ) const;
-
-                    CompletionItem completionItem( void ) const;
-
-                    void completionItem( const CompletionItem& completionItem );
-
-                    static void validate( const Data& data );
-                };
-
-                class CompletionItem : public Data
-                {
-                  public:
-                    CompletionItem( const Data& data );
-
-                    CompletionItem( void );
-
-                    u1 hasSnippetSupport( void ) const;
-
-                    u1 snippetSupport( void ) const;
-
-                    void setSnippetSupport( const u1 snippetSupport );
-
-                    static void validate( const Data& data );
-                };
-            };
-
-            class ClientCapabilities : public Data
-            {
-              public:
-                ClientCapabilities( const Data& data );
-
-                ClientCapabilities( void );
-
-                u1 hasWorkspace( void ) const;
-
-                WorkspaceClientCapabilities workspace( void ) const;
-
-                void setWorkspace( const WorkspaceClientCapabilities& workspace );
-
-                u1 hasTextDocument( void ) const;
-
-                TextDocumentClientCapabilities textDocument( void ) const;
-
-                void setTextDocument( const TextDocumentClientCapabilities& textDocument );
-
-                u1 hasExperimental( void ) const;
-
-                Data experimental( void ) const;
-
-                void setExperimental( const Data& experimental );
-
-                static void validate( const Data& data );
-            };
-
-            class SaveOptions : public Data
-            {
-              public:
-                SaveOptions( const Data& data );
-
-                SaveOptions( void );
-
-                u1 hasIncludeText( void ) const;
-
-                u1 includeText( void ) const;
-
-                void setIncludeText( const u1 includeText );
-
-                static void validate( const Data& data );
-            };
-
-            enum class TextDocumentSyncKind
-            {
-                None = 0,
-                Full = 1,
-                Incremental = 2,
-            };
-
-            class TextDocumentSyncOptions : public Data
-            {
-              public:
-                TextDocumentSyncOptions( const Data& data );
-
-                TextDocumentSyncOptions( void );
-
-                u1 hasOpenClose( void ) const;
-
-                u1 openClose( void ) const;
-
-                void setOpenClose( const u1 openClose );
-
-                u1 hasChange( void ) const;
-
-                TextDocumentSyncKind change( void ) const;
-
-                void setChange( const TextDocumentSyncKind& change );
-
-                u1 hasWillSave( void ) const;
-
-                u1 willSave( void ) const;
-
-                void setWillSave( const u1 willSave );
-
-                u1 hasWillSaveWaitUntil( void ) const;
-
-                u1 willSaveWaitUntil( void ) const;
-
-                void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
-
-                u1 hasSave( void ) const;
-
-                SaveOptions save( void ) const;
-
-                void setSave( const SaveOptions& save );
-
-                static void validate( const Data& data );
-            };
-
-            class CompletionOptions : public Data
-            {
-              public:
-                CompletionOptions( const Data& data );
-
-                CompletionOptions( void );
-
-                u1 hasResolveProvider( void ) const;
-
-                u1 resolveProvider( void ) const;
-
-                void setResolveProvider( const u1 resolveProvider );
-
-                u1 hasTriggerCharacters( void ) const;
-
-                Data triggerCharacters( void ) const;
-
-                void addTriggerCharacters( const std::string& triggerCharacter );
-
-                static void validate( const Data& data );
-            };
-
-            class SignatureHelpOptions : public Data
-            {
-              public:
-                SignatureHelpOptions( const Data& data );
-
-                SignatureHelpOptions( void );
-
-                u1 hasTriggerCharacters( void ) const;
-
-                Data triggerCharacters( void ) const;
-
-                void addTriggerCharacters( const std::string& triggerCharacter );
-
-                static void validate( const Data& data );
-            };
-
-            class CodeLensOptions : public Data
-            {
-              public:
-                CodeLensOptions( const Data& data );
-
-                CodeLensOptions( void );
-
-                u1 hasResolveProvider( void ) const;
-
-                u1 resolveProvider( void ) const;
-
-                void setResolveProvider( const u1 resolveProvider );
-
-                static void validate( const Data& data );
-            };
-
-            class DocumentOnTypeFormattingOptions : public Data
-            {
-              public:
-                DocumentOnTypeFormattingOptions( const Data& data );
-
-                DocumentOnTypeFormattingOptions( const std::string& firstTriggerCharacter );
-
-                std::string firstTriggerCharacter( void ) const;
-
-                u1 hasMoreTriggerCharacter( void ) const;
-
-                Data moreTriggerCharacter( void ) const;
-
-                void addMoreTriggerCharacter( const Data& moreTriggerCharacter );
-
-                static void validate( const Data& data );
-            };
-
-            class RenameOptions : public Data
-            {
-              public:
-                RenameOptions( const Data& data );
-
-                u1 hasPrepareProvider( void ) const;
-
-                u1 prepareProvider( void ) const;
-
-                void setPrepareProvider( const u1 prepareProvider );
-
-                static void validate( const Data& data );
-            };
-
-            using DocumentLinkOptions = CodeLensOptions;
-
-            class ExecuteCommandOptions : public Data
-            {
-              public:
-                ExecuteCommandOptions( const Data& data );
-
-                ExecuteCommandOptions( void );
-
-                u1 hasCommands( void ) const;
-
-                Data commands( void ) const;
-
-                void addCommand( const std::string& command );
-
-                static void validate( const Data& data );
-            };
-            class StaticRegistrationOptions : public Data
-            {
-              public:
-                StaticRegistrationOptions( const Data& data );
-
-                u1 hasId( void ) const;
-
-                std::string id( void ) const;
-
-                void setId( std::string id );
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentRegistrationOptions : public Data
-            {
-              public:
-                TextDocumentRegistrationOptions( const Data& data );
-
-                TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
-
-                DocumentSelector documentSelector( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TypeDefinitionProvider : public Data
-            {
-              public:
-                TypeDefinitionProvider( const Data& data );
-
-                DocumentSelector documentSelector( void ) const;
-
-                u1 hasId( void ) const;
-
-                std::string id( void ) const;
-
-                void setId( std::string id );
-
-                static void validate( const Data& data );
-            };
-
-            using ImplementationProvider = TypeDefinitionProvider;
-
-            class ColorProviderOptions : public Data
-            {
-              public:
-                ColorProviderOptions( const Data& data );
-
-                static void validate( const Data& data );
-            };
-
-            using FoldingRangeProviderOptions = ColorProviderOptions;
-
-            class ColorProvider : public Data
-            {
-              public:
-                ColorProvider( const Data& data );
-
-                DocumentSelector documentSelector( void ) const;
-
-                u1 hasId( void ) const;
-
-                std::string id( void ) const;
-
-                void setId( std::string id );
-
-                static void validate( const Data& data );
-            };
-
-            using FoldingRangeProvider = ColorProvider;
-
-            class Workspace : public Data
-            {
-              public:
-                Workspace( const Data& data );
-
-                static void validate( const Data& data );
-
-                class WorkspaceFolders : public Data
-                {
-                  public:
-                    WorkspaceFolders( const Data& data );
-
-                    u1 supported( void ) const;
-
-                    u1 hasSupported( void ) const;
-
-                    void setSupported( const u1 supported );
-
-                    void setChangeNotifications( const std::string& changeNotifications );
-
-                    void setChangeNotifications( const u1 changeNotifications );
-
-                    u1 hasChangeNotifications( void ) const;
-
-                    std::string changeNotifications( void ) const;
-
-                    static void validate( const Data& data );
-                };
-                WorkspaceFolders workspaceFolders( void ) const;
-
-                u1 hasWorkspaceFolders( void ) const;
-
-                void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
-            };
-            class ServerCapabilities : public Data
-            {
-              public:
-                ServerCapabilities( const Data& data );
-
-                ServerCapabilities( void );
-
-                u1 hasTextDocumentSync( void ) const;
-
-                TextDocumentSyncOptions textDocumentSync( void ) const;
-
-                void setTextDocumentSync( const TextDocumentSyncOptions& textDocumentSync );
-
-                void setTextDocumentSync( const TextDocumentSyncKind& textDocumentSync );
-
-                u1 hasHoverProvider( void ) const;
-
-                u1 hoverProvider( void ) const;
-
-                void setHoverProvider( const u1 hoverProvider );
-
-                u1 hasCompletionProvider( void ) const;
-
-                CompletionOptions completionProvider( void ) const;
-
-                void setCompletionProvider( const CompletionOptions& completionProvider );
-
-                u1 hasSignatureHelpProvider( void ) const;
-
-                SignatureHelpOptions signatureHelpProvider( void ) const;
-
-                void setSignatureHelpProvider( const SignatureHelpOptions& signatureHelpProvider );
-
-                u1 hasDefinitionProvider( void ) const;
-
-                u1 definitionProvider( void ) const;
-
-                void setDefinitionProvider( const u1 definitionProvider );
-
-                u1 hasTypeDefinitionProvider( void ) const;
-
-                TypeDefinitionProvider typeDefinitionProvider( void ) const;
-
-                void setTypeDefinitionProvider(
-                    const TypeDefinitionProvider& typeDefinitionProvider );
-
-                u1 hasImplementationProvider( void ) const;
-
-                ImplementationProvider implementationProvider( void ) const;
-
-                void setImplementationProvider(
-                    const ImplementationProvider& implementationProvider );
-
-                u1 hasReferencesProvider( void ) const;
-
-                u1 referencesProvider( void ) const;
-
-                void setReferencesProvider( const u1 referencesProvider );
-
-                u1 hasDocumentHighlightProvider( void ) const;
-
-                u1 documentHighlightProvider( void ) const;
-
-                void setDocumentHighlightProvider( const u1 documentHighlightProvider );
-
-                u1 hasDocumentSymbolProvider( void ) const;
-
-                u1 documentSymbolProvider( void ) const;
-
-                void setDocumentSymbolProvider( const u1 documentSymbolProvider );
-
-                u1 hasWorkspaceSymbolProvider( void ) const;
-
-                u1 workspaceSymbolProvider( void ) const;
-
-                void setWorkspaceSymbolProvider( const u1 workspaceSymbolProvider );
-
-                u1 hasCodeActionProvider( void ) const;
-
-                u1 codeActionProvider( void ) const;
-
-                void setCodeActionProvider( const u1 codeActionProvider );
-
-                u1 hasCodeLensProvider( void ) const;
-
-                CodeLensOptions codeLensProvider( void ) const;
-
-                void setCodeLensProvider( const CodeLensOptions& codeLensProvider );
-
-                u1 hasDocumentFormattingProvider( void ) const;
-
-                u1 documentFormattingProvider( void ) const;
-
-                void setDocumentFormattingProvider( const u1 documentFormattingProvider );
-
-                u1 hasDocumentRangeFormattingProvider( void ) const;
-
-                u1 documentRangeFormattingProvider( void ) const;
-
-                void setDocumentRangeFormattingProvider( const u1 documentRangeFormattingProvider );
-
-                u1 hasDocumentOnTypeFormattingProvider( void ) const;
-
-                DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider( void ) const;
-
-                void setDocumentOnTypeFormattingProvider(
-                    const DocumentOnTypeFormattingOptions& documentOnTypeFormattingProvider );
-
-                u1 hasRenameProvider( void ) const;
-
-                u1 renameProvider( void ) const;
-
-                void setRenameProvider( const u1 renameProvider );
-
-                u1 hasDocumentLinkProvider( void ) const;
-
-                DocumentLinkOptions documentLinkProvider( void ) const;
-
-                void setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider );
-
-                u1 hasColorProvider( void ) const;
-
-                ColorProvider colorProvider( void ) const;
-
-                void setColorProvider( const ColorProvider& colorProvider );
-
-                u1 hasFoldingRangeProvider( void ) const;
-
-                FoldingRangeProvider foldingRangeProvider( void ) const;
-
-                void setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider );
-
-                u1 hasExecuteCommandProvider( void ) const;
-
-                ExecuteCommandOptions executeCommandProvider( void ) const;
-
-                void setExecuteCommandProvider(
-                    const ExecuteCommandOptions& executeCommandProvider );
-
-                u1 hasExperimental( void ) const;
-
-                Data experimental( void ) const;
-
-                void setExperimental( const Data& experimental );
-
-                u1 hasWorkspace( void ) const;
-
-                void setWorkspace( const Workspace& workspace );
-
-                Workspace workspace( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceFolder : public Data
-            {
-              public:
-                WorkspaceFolder( const std::string& uri, const std::string& name );
-
-                WorkspaceFolder( const Data& data );
-
-                std::string uri( void ) const;
-
-                std::string name( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using WorkspaceFolders = std::vector< WorkspaceFolder >;
-
-            class InitializeParams : public Data
-            {
-              public:
-                InitializeParams( const Data& data );
-
-                InitializeParams(
-                    const std::size_t processId,
-                    const DocumentUri& rootUri,
-                    const ClientCapabilities& capabilities );
-
-                std::size_t processId( void ) const;
-
-                // rootPath interface omitted!
-
-                DocumentUri rootUri( void ) const;
-
-                u1 hasInitializationOptions( void ) const;
-
-                Data initializationOptions( void ) const;
-
-                void setInitializationOptions( const Data& initializationOptions );
-
-                ClientCapabilities capabilities( void ) const;
-
-                u1 hasTrace( void ) const;
-
-                std::string trace( void ) const;
-
-                void setTrace( const std::string& trace );
-
-                WorkspaceFolders workspaceFolders( void ) const;
-
-                u1 hasWorkspaceFolders( void ) const;
-
-                void addWorkspaceFolder( WorkspaceFolder folder );
-
-                static void validate( const Data& data );
-            };
-
-            class InitializeResult : public Data
-            {
-              public:
-                InitializeResult( const Data& data );
-
-                InitializeResult( const ServerCapabilities& capabilities );
-
-                ServerCapabilities capabilities( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class InitializeError : public Data
-            {
-              public:
-                InitializeError( const Data& data );
-
-                InitializeError( const u1 retry );
-
-                u1 retry( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class MessageType
-            {
-                Error = 1,
-
-                Warning = 2,
-
-                Info = 3,
-
-                Log = 4
-            };
-
-            class CancelParams : public Data
-            {
-              public:
-                CancelParams( const Data& data );
-
-                CancelParams( const std::size_t& id );
-
-                CancelParams( const std::string& id );
-
-                std::string id( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class ShowMessageParams : public Data
-            {
-              public:
-                ShowMessageParams( const Data& data );
-
-                ShowMessageParams( const MessageType type, const std::string& message );
-
-                MessageType messageType( void ) const;
-
-                std::string message( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class MessageActionItem : public Data
-            {
-              public:
-                MessageActionItem( const Data& data );
-
-                MessageActionItem( const std::string& title );
-
-                std::string title( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class ShowMessageRequestResult : public Data
-            {
-              public:
-                ShowMessageRequestResult( void );
-
-                ShowMessageRequestResult( const Data& data );
-
-                ShowMessageRequestResult( const MessageActionItem& item );
-
-                ShowMessageRequestResult( const std::string& title );
-
-                static void validate( const Data& data );
-            };
-
-            using MessageActionItems = std::vector< MessageActionItem >;
-
-            class ShowMessageRequestParams : public Data
-            {
-              public:
-                ShowMessageRequestParams( const Data& data );
-
-                ShowMessageRequestParams( const MessageType type, const std::string& message );
-
-                MessageType messageType( void ) const;
-
-                u1 hasActions( void );
-
-                MessageActionItems actions( void ) const;
-
-                void addAction( const MessageActionItem& action );
-
-                std::string message( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using LogMessageParams = ShowMessageParams;
-
-            class TelemetryEventParams : public Data
-            {
-              public:
-                TelemetryEventParams( const Data& data );
-
-                static void validate( const Data& data );
-            };
-
-            class Registration : public Data
-            {
-              public:
-                Registration( const Data& data );
-
-                Registration( const std::string& id, const std::string& method );
-
-                std::string id( void ) const;
-
-                std::string method( void ) const;
-
-                Data registerOptions( void ) const;
-
-                u1 hasRegisterOptions( void ) const;
-
-                void addRegisterOption( const Data& option );
-
-                static void validate( const Data& data );
-            };
-
-            using Registrations = std::vector< Registration >;
-
-            class RegistrationParams : public Data
-            {
-              public:
-                RegistrationParams( const Data& data );
-
-                RegistrationParams( const Registrations& registrations );
-
-                Registrations registrations( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentChangeRegistrationOptions : public TextDocumentRegistrationOptions
-            {
-              public:
-                TextDocumentChangeRegistrationOptions( const Data& data );
-
-                TextDocumentChangeRegistrationOptions(
-                    const DocumentSelector& documentSelector, TextDocumentSyncKind kind );
-
-                TextDocumentSyncKind kind( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentSaveRegistrationOptions : public TextDocumentRegistrationOptions
-            {
-              public:
-                TextDocumentSaveRegistrationOptions( const Data& data );
-
-                TextDocumentSaveRegistrationOptions( const DocumentSelector& documentSelector );
-
-                u1 hasIncludeText( void ) const;
-
-                void setIncludeText( const u1 includeText );
-
-                u1 includeText( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using TriggerCharacters = std::vector< std::string >;
-
-            class SignatureHelpRegistrationOptions : public TextDocumentRegistrationOptions
-            {
-              public:
-                SignatureHelpRegistrationOptions( const Data& data );
-
-                SignatureHelpRegistrationOptions( const DocumentSelector& documentSelector );
-
-                u1 hasTriggerCharacters( void ) const;
-
-                void setTriggerCharacters( const TriggerCharacters& triggerCharacters );
-
-                void addTriggerCharacter( const std::string& triggerCharacter );
-
-                TriggerCharacters triggerCharacters( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class Unregistration : public Data
-            {
-              public:
-                Unregistration( const Data& data );
-
-                Unregistration( const std::string& id, const std::string& method );
-
-                std::string id( void ) const;
-
-                std::string method( void ) const;
-
-                static void validate( const Data& data );
-            };
-            using Unregistrations = std::vector< Unregistration >;
-
-            class UnregistrationParams : public Data
-            {
-              public:
-                UnregistrationParams( const std::vector< Unregistration >& unregistrations );
-
-                UnregistrationParams( const Data& data );
-
-                Unregistrations unregistrations( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceFoldersResult : public Data
-            {
-              public:
-                WorkspaceFoldersResult();
-
-                WorkspaceFoldersResult( const Data& data );
-
-                WorkspaceFoldersResult( const WorkspaceFolders& workspaceFolders );
-
-                WorkspaceFolders toVec( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceFoldersChangeEvent : public Data
-            {
-              public:
-                WorkspaceFoldersChangeEvent(
-                    const WorkspaceFolders& added, const WorkspaceFolders& removed );
-
-                WorkspaceFoldersChangeEvent( const Data& data );
-
-                WorkspaceFolders added( void ) const;
-
-                WorkspaceFolders removed( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class DidChangeWorkspaceFoldersParams : public Data
-            {
-              public:
-                DidChangeWorkspaceFoldersParams( const Data& data );
-
-                DidChangeWorkspaceFoldersParams( const WorkspaceFoldersChangeEvent& event );
-
-                WorkspaceFoldersChangeEvent event( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using DidChangeConfigurationSettings = Data;
-
-            class DidChangeConfigurationParams : public Data
-            {
-              public:
-                DidChangeConfigurationParams( const DidChangeConfigurationSettings& settings );
-
-                DidChangeConfigurationSettings settings( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class ConfigurationItem : public Data
-            {
-              public:
-                ConfigurationItem( const Data& data );
-
-                ConfigurationItem( const std::string& scopeUri, const std::string& section );
-
-                u1 hasScopeUri( void ) const;
-
-                u1 hasSection( void ) const;
-
-                std::string scopeUri( void ) const;
-
-                std::string section( void ) const;
-
-                void setSection( const std::string& section );
-
-                void setScopeUri( const std::string& uri );
-
-                static void validate( const Data& data );
-            };
-
-            class ConfigurationResult : public Data
-            {
-              public:
-                ConfigurationResult( void );
-
-                ConfigurationResult( const Data& data );
-
-                static void validate( const Data& data );
-            };
+                u1 hasCompletionItem( void ) const;
 
-            using ConfigurationItems = std::vector< ConfigurationItem >;
+                CompletionItem completionItem( void ) const;
 
-            class ConfigurationParams : public Data
-            {
-              public:
-                ConfigurationParams( const ConfigurationItems& items );
+                void completionItem( const CompletionItem& completionItem );
 
-                ConfigurationParams( const Data& data );
-
-                ConfigurationItems items( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class FileChangeType
-            {
-                Created = 1,
-
-                Changed = 2,
-
-                Deleted = 3
-            };
-
-            /**
-              An event describing a file change.
-             */
-            class FileEvent : public Data
-            {
-              public:
-                FileEvent( const Data& data );
-
-                FileEvent( const DocumentUri& uri, const FileChangeType type );
-
-                DocumentUri documentUri( void ) const;
-
-                FileChangeType type( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using FileEvents = std::vector< FileEvent >;
-
-            class DidChangeWatchedFilesParams : public Data
-            {
-              public:
-                DidChangeWatchedFilesParams( const FileEvents& changes );
-
-                DidChangeWatchedFilesParams( const Data& data );
-
-                FileEvents changes( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class WatchKind
-            {
-
-                Create = 1,
-
-                Change = 2,
-
-                Delete = 4
-            };
-
-            class FileSystemWatcher : public Data
-            {
-              public:
-                FileSystemWatcher( const Data& data );
-
-                FileSystemWatcher( const std::string& globPattern );
-
-                FileSystemWatcher( const std::string& globPattern, const WatchKind kind );
-
-                std::string globPattern( void );
-
-                u1 hasKind( void ) const;
-
-                WatchKind kind( void ) const;
-
-                static void validate( const Data& data );
-
-                void setKind( const WatchKind kind );
-            };
-
-            /**
-              Describe options to be used when registering for text document change events.
-             */
-            using FileSystemWatchers = std::vector< FileSystemWatcher >;
-            class DidChangeWatchedFilesRegistrationOptions : public Data
-            {
-              public:
-                DidChangeWatchedFilesRegistrationOptions( const FileSystemWatchers& watchers );
-
-                DidChangeWatchedFilesRegistrationOptions( const Data& data );
-
-                FileSystemWatchers watchers( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class WorkspaceSymbolParams : public Data
-            {
-              public:
-                WorkspaceSymbolParams( const Data& data );
-
-                WorkspaceSymbolParams( const std::string& query );
-
-                std::string query( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class SymbolKind
-            {
-                File = 1,
-                Module = 2,
-                Namespace = 3,
-                Package = 4,
-                Class = 5,
-                Method = 6,
-                Property = 7,
-                Field = 8,
-                Constructor = 9,
-                Enum = 10,
-                Interface = 11,
-                Function = 12,
-                Variable = 13,
-                Constant = 14,
-                String = 15,
-                Number = 16,
-                Boolean = 17,
-                Array = 18,
-                Object = 19,
-                Key = 20,
-                Null = 21,
-                EnumMember = 22,
-                Struct = 23,
-                Event = 24,
-                Operator = 25,
-                TypeParameter = 26
-            };
-
-            class SymbolInformation : public Data
-            {
-              public:
-                SymbolInformation(
-                    const std::string& name, const SymbolKind kind, const Location& location );
-
-                SymbolInformation( const Data& data );
-
-                u1 isDeprecated( void ) const;
-
-                u1 hasDeprecated( void ) const;
-
-                void setDeprecated( const u1 deprecated );
-
-                std::string containerName( void ) const;
-
-                u1 hasContainerName( void ) const;
-
-                void setContainerName( const std::string& containerName );
-
-                Location location( void ) const;
-
-                std::string name( void ) const;
-
-                SymbolKind kind( void ) const;
-
-                static void validate( const Data& data );
-            };
-            using SymbolInformations = std::vector< SymbolInformation >;
-            class WorkspaceSymbolResult : public Data
-            {
-              public:
-                WorkspaceSymbolResult( const Data& data );
-
-                WorkspaceSymbolResult( const std::vector< SymbolInformation >& symbolInformation );
-
-                void addSymbolInformation( const SymbolInformation& information );
-
-                SymbolInformations symbolInformation( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class ApplyWorkspaceEditParams : public Data
-            {
-              public:
-                ApplyWorkspaceEditParams( const Data& data );
-
-                ApplyWorkspaceEditParams( const WorkspaceEdit& edit );
-
-                WorkspaceEdit edit( void ) const;
-
-                u1 hasLabel( void ) const;
-
-                std::string label( void ) const;
-
-                void setLabel( const std::string& label );
-
-                static void validate( const Data& data );
-            };
-
-            class ApplyWorkspaceEditResult : public Data
-            {
-              public:
-                ApplyWorkspaceEditResult( const Data& data );
-
-                ApplyWorkspaceEditResult( const u1 applied );
-
-                u1 applied( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class ConfigurationItem : public Data
-            {
-              
-              public: 
-
-              ConfigurationItem( const Data& data );
-
-              ConfigurationItem( const std::string& scopeUri, const std::string& section );
-
-              u1 hasScopeUri( void ) const;
-
-              u1 hasSection( void ) const;
-
-              std::string scopeUri( void ) const;
-              
-              std::string section( void ) const;
-
-              void setSection (const std::string& section);
-
-              void setScopeUri(const std::string& uri);
-
-              u1 isValid(const Data& data);
-
-            };
-
-              class ConfigurationParams 
-            {
-
-              ConfigurationParams( const std::vector<ConfigurationItem>& items );
-              
-              ConfigurationParams( const Data& data);
-            };
-
-            /**
-             * The file event type.
-             */
-            enum class FileChangeType 
-            {
-              /**
-               * The file got created.
-               */
-              Created = 1,
-              /**
-               * The file got changed.
-               */
-              Changed = 2,
-              /**
-               * The file got deleted.
-               */
-              Deleted = 3
-            };
-
-            /**
-             * An event describing a file change.
-             */
-            class FileEvent : public Data
-            {
-
-              FileEvent( const Data& data);
-
-              FileEvent( const DocumentUri& uri, const FileChangeType type);
-
-              u1 isValid( const Data& data );
-
-              DocumentUri documentUri( void ) const;
-
-              FileChangeType type( void ) const;
-
-            };
-
-            class DidChangeWatchedFilesParams 
-            {
-
-              DidChangeWatchedFilesParams( const std::vector<FileEvent>& changes);
-
-              DidChangeWatchedFilesParams( const Data& data);
-
-            };
-
-
-             enum class WatchKind 
-            {
-              /**
-               * Interested in create events.
-               */
-             Create = 1,
-
-              /**
-               * Interested in change events
-               */
-             Change = 2,
-
-              /**
-               * Interested in delete events
-               */
-              Delete = 4
-            };
-
-
-            class FileSystemWatcher : public Data
-            {
-              
-              public:
-
-              FileSystemWatcher ( const Data& data);
-
-              FileSystemWatcher ( const std::string& globPattern);
-
-              FileSystemWatcher ( const std::string& globPattern, const WatchKind kind);
-
-              std::string pattern( void );
-
-              u1 hasKind( void ) const;
-
-              WatchKind kind( void ) const;
-
-              u1 isValid ( const Data& data);
-
-              void setKind ( const WatchKind kind);
-            };
-
-            /**
-             * Describe options to be used when registering for text document change events.
-             */
-            class DidChangeWatchedFilesRegistrationOptions 
-            {
-              
-              public:
-
-              DidChangeWatchedFilesRegistrationOptions ( const std::vector<FileSystemWatcher>& watchers);
-
-              DidChangeWatchedFilesRegistrationOptions( const Data& data );
-
-              std::vector<FileSystemWatcher> watchers( void ) const;
-              
-            };
-
-            class WorkspaceSymbolParams : public Data{
-
-              public:
-
-              WorkspaceSymbolParams( const Data& data);
-
-              WorkspaceSymbolParams( const std::string query);
-
-              std::string query( void ) const;
-
-              u1 isValid(const Data& data);
-             
-            };
-         
-            class ApplyWorkspaceEditParams : public Data
-            {
-              
-              public:
-              ApplyWorkspaceEditParams( const Data& data );
-
-              ApplyWorkspaceEditParams( const WorkspaceEdit& edit );
-              
-              WorkspaceEdit edit( void ) const;
-
-              u1 hasLabel( void ) const;
-
-              std::string label( void ) const;
-              
-              void setLabel( const std::string& label );
-
-              void setLabel( const Data& data);
-
-              u1 isValid ( const Data& data ) const;
-
-            };
-
-            class ApplyWorkspaceEditResponse
-            {
-              /**
-               * Indicates whether the edit was applied or not.
-               */
-              ApplyWorkspaceEditResponse(const Data& data );
-
-              ApplyWorkspaceEditResponse( const u1& applied );
-
-              u1 isApplied( void ) const;
-
-              void applied ( u1 applied );
-
-              u1 isValid( const Data& data );
-            };
-
-            class DidOpenTextDocumentParams : public Data
-            {
-              public:
-                DidOpenTextDocumentParams( const Data& data );
-
-                DidOpenTextDocumentParams( const TextDocumentItem& textDocument );
-
-                TextDocumentItem textDocument( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class TextDocumentContentChangeEvent : public Data
-            {
-              public:
-                TextDocumentContentChangeEvent( const Data& data );
-
-                TextDocumentContentChangeEvent( const std::string& text );
-
-                u1 hasRange( void ) const;
-
-                Range range( void ) const;
-
-                void setRange( const Range& range );
-
-                u1 hasRangeLength( void ) const;
-
-                std::size_t rangeLength( void ) const;
-
-                void setRangeLength( const std::size_t rangeLength );
-
-                std::string text( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using TextDocumentContentChangeEvents = std::vector< TextDocumentContentChangeEvent >;
-
-            class DidChangeTextDocumentParams : public Data
-            {
-              public:
-                DidChangeTextDocumentParams( const Data& data );
-
-                DidChangeTextDocumentParams(
-                    const VersionedTextDocumentIdentifier& textDocument,
-                    const TextDocumentContentChangeEvents& contentChanges );
-
-                VersionedTextDocumentIdentifier textDocument( void ) const;
-
-                TextDocumentContentChangeEvents contentChanges( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            enum class TextDocumentSaveReason
-            {
-                Manual = 1,  // by the user pressing save, by starting debugging, or by an API call.
-                AfterDelay = 2,  // Automatic after a delay.
-                FocusOut = 3     //  When the editor lost focus.
-            };
-
-            class WillSaveTextDocumentParams : public Data
-            {
-              public:
-                WillSaveTextDocumentParams( const Data& data );
-
-                WillSaveTextDocumentParams(
-                    const TextDocumentIdentifier& textDocument, TextDocumentSaveReason reason );
-
-                TextDocumentSaveReason reason( void ) const;
-
-                TextDocumentIdentifier textDocument( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            using TextEdits = std::vector< TextEdit >;
-
-            class WillSaveWaitUntilResponse : public Data
-            {
-              public:
-                WillSaveWaitUntilResponse( const Data& data );
-
-                WillSaveWaitUntilResponse( const std::vector< TextEdit >& textEdit );
-
-                TextEdits textEdit( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class DidSaveTextDocumentParams : public Data
-            {
-              public:
-                DidSaveTextDocumentParams( const Data& data );
-
-                DidSaveTextDocumentParams( const TextDocumentIdentifier& textDocument );
-
-                u1 hasText( void ) const;
-
-                void setText( const std::string& text );
-
-                TextDocumentIdentifier textDocument( void ) const;
-
-                std::string text( void ) const;
-
-                static void validate( const Data& data );
-            };
-            class DidCloseTextDocumentParams : public Data
-            {
-              public:
-                DidCloseTextDocumentParams( const TextDocumentIdentifier& textDocument );
-
-                DidCloseTextDocumentParams( const Data& data );
-
-                TextDocumentIdentifier textDocument( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class CompletionRegistrationOptions : public TextDocumentRegistrationOptions
-            {
-              public:
-                CompletionRegistrationOptions( const Data& data );
-
-                CompletionRegistrationOptions( const DocumentSelector& documentSelector );
-
-                u1 hasTriggerCharacters( void ) const;
-
-                TriggerCharacters triggerCharacters( void ) const;
-
-                void addTriggerCharacter( const std::string& triggerCharacter );
-
-                u1 hasResolveProvider( void ) const;
-
-                u1 resolveProvider( void ) const;
-
-                void setResolveProvider( const u1 resolveProvider );
-
-                static void validate( const Data& data );
-            };
-
-            enum class CompletionTriggerKind
-            {
-                /**
-                 * Completion was triggered by typing an identifier (24x7 code
-                 * complete), manual invocation (e.g Ctrl+Space) or via API.
-                 */
-                Invoked = 1,
-
-                /**
-                 * Completion was triggered by a trigger character specified by
-                 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-                 */
-                TriggerCharacter = 2,
-
-                /**
-                 * Completion was re-triggered as the current completion list is incomplete.
-                 */
-                TriggerForIncompleteCompletions = 3
-            };
-
-            class CompletionContext : public Data
-            {
-              public:
-                CompletionContext( const Data& data );
-
-                CompletionContext( const CompletionTriggerKind triggerkind );
-
-                std::string triggerCharacter( void ) const;
-
-                void setTriggerCharacter( const std::string& triggerCharacter );
-
-                u1 hasTriggerCharacter( void ) const;
-
-                CompletionTriggerKind triggerKind( void ) const;
-
-                static void validate( const Data& data );
-            };
-
-            class CompletionParams : public TextDocumentPositionParams
-            {
-              public:
-                CompletionParams( const Data& data );
-
-                CompletionParams(
-                    const TextDocumentIdentifier& textDocument, const Position& position );
-
-                CompletionContext context( void ) const;
-
-                u1 hasContext( void ) const;
-
-                void setContext( const CompletionContext& context );
-
-                static void validate( const Data& data );
-            };
-
-            enum class MarkupKind
-            {
-                PLAINTEXT,
-                MARKDOWN
-            };
-
-            class MarkupContent : public Data
-            {
-              public:
-                MarkupContent( const Data& data );
-
-                MarkupContent( const std::string& value );  // kind will be plaintext
-
-                MarkupContent( const MarkupKind kind, const std::string& value );
-
-                std::string kind( void ) const;
-
-                std::string value( void ) const;
-
                 static void validate( const Data& data );
             };
-
-            enum class InsertTextFormat
-            {
-                PlainText = 1,
-                Snippet = 2
-            };
-
-            enum class CompletionItemKind
-            {
-                Text = 1,
-                Method = 2,
-                Function = 3,
-                Constructor = 4,
-                Field = 5,
-                Variable = 6,
-                Class = 7,
-                Interface = 8,
-                Module = 9,
-                Property = 10,
-                Unit = 11,
-                Value = 12,
-                Enum = 13,
-                Keyword = 14,
-                Snippet = 15,
-                Color = 16,
-                File = 17,
-                Reference = 18,
-                Folder = 19,
-                EnumMember = 20,
-                Constant = 21,
-                Struct = 22,
-                Event = 23,
-                Operator = 24,
-                TypeParameter = 25
-            };
-
-            using CommitCharacters = std::vector< std::string >;
 
             class CompletionItem : public Data
             {
               public:
                 CompletionItem( const Data& data );
 
-                CompletionItem( const std::string& label );
+                CompletionItem( void );
 
-                std::string label( void ) const;
+                u1 hasSnippetSupport( void ) const;
 
-                u1 hasKind( void ) const;
+                u1 snippetSupport( void ) const;
 
-                void setKind( const CompletionItemKind kind );
-
-                CompletionItemKind kind( void ) const;
-
-                u1 hasDetail( void ) const;
-
-                void setDetail( const std::string& detail );
-
-                std::string detail( void ) const;
-
-                u1 hasDocumentation( void ) const;
-
-                void setDocumentation( const MarkupContent& doc );
-
-                MarkupContent documentation( void ) const;
-
-                u1 hasDeprecated( void ) const;
-
-                void setDeprecated( const u1 deprecated );
-
-                u1 isDeprecated( void ) const;
-
-                u1 hasPreselected( void ) const;
-
-                void setPreselected( const u1 preselected );
-
-                u1 isPreselected( void ) const;
-
-                u1 hasSortText( void ) const;
-
-                void setSortText( const std::string& sortText );
-
-                std::string sortText( void ) const;
-
-                u1 hasFilterText( void ) const;
-
-                void setFilterText( const std::string& filterText );
-
-                std::string filterText( void ) const;
-
-                u1 hasInsertText( void ) const;
-
-                void setInsertText( const std::string& insertText );
-
-                std::string insertText( void ) const;
-
-                u1 hasInsertTextFormat( void ) const;
-
-                void setInsertTextFormat( const InsertTextFormat insertTextFormat );
-
-                InsertTextFormat insertTextFormat( void ) const;
-
-                u1 hasTextEdit( void ) const;
-
-                void setTextEdit( const TextEdit& textEdit );
-
-                TextEdit textEdit( void ) const;
-
-                u1 hasAdditionalTextEdits( void ) const;
-
-                void addAdditionalTextEdit( const TextEdit& textEdit );
-
-                TextEdits additionalTextEdits( void ) const;
-
-                u1 hasCommitCharacters( void ) const;
-
-                void addCommitCharacter( const std::string& commitCharacter );
-
-                CommitCharacters commitCharacters( void ) const;
-
-                u1 hasCommand( void ) const;
-
-                void setCommand( const Command& command );
-
-                Command command( void ) const;
-
-                u1 hasData( void ) const;
-
-                void setData( const Data& data );
-
-                Data data( void ) const;
+                void setSnippetSupport( const u1 snippetSupport );
 
                 static void validate( const Data& data );
             };
+        };
 
-            using CompletionItems = std::vector< CompletionItem >;
-            class CompletionList : public Data
+        class ClientCapabilities : public Data
+        {
+          public:
+            ClientCapabilities( const Data& data );
+
+            ClientCapabilities( void );
+
+            u1 hasWorkspace( void ) const;
+
+            WorkspaceClientCapabilities workspace( void ) const;
+
+            void setWorkspace( const WorkspaceClientCapabilities& workspace );
+
+            u1 hasTextDocument( void ) const;
+
+            TextDocumentClientCapabilities textDocument( void ) const;
+
+            void setTextDocument( const TextDocumentClientCapabilities& textDocument );
+
+            u1 hasExperimental( void ) const;
+
+            Data experimental( void ) const;
+
+            void setExperimental( const Data& experimental );
+
+            static void validate( const Data& data );
+        };
+
+        class SaveOptions : public Data
+        {
+          public:
+            SaveOptions( const Data& data );
+
+            SaveOptions( void );
+
+            u1 hasIncludeText( void ) const;
+
+            u1 includeText( void ) const;
+
+            void setIncludeText( const u1 includeText );
+
+            static void validate( const Data& data );
+        };
+
+        enum class TextDocumentSyncKind
+        {
+            None = 0,
+            Full = 1,
+            Incremental = 2,
+        };
+
+        class TextDocumentSyncOptions : public Data
+        {
+          public:
+            TextDocumentSyncOptions( const Data& data );
+
+            TextDocumentSyncOptions( void );
+
+            u1 hasOpenClose( void ) const;
+
+            u1 openClose( void ) const;
+
+            void setOpenClose( const u1 openClose );
+
+            u1 hasChange( void ) const;
+
+            TextDocumentSyncKind change( void ) const;
+
+            void setChange( const TextDocumentSyncKind& change );
+
+            u1 hasWillSave( void ) const;
+
+            u1 willSave( void ) const;
+
+            void setWillSave( const u1 willSave );
+
+            u1 hasWillSaveWaitUntil( void ) const;
+
+            u1 willSaveWaitUntil( void ) const;
+
+            void setWillSaveWaitUntil( const u1 willSaveWaitUntil );
+
+            u1 hasSave( void ) const;
+
+            SaveOptions save( void ) const;
+
+            void setSave( const SaveOptions& save );
+
+            static void validate( const Data& data );
+        };
+
+        class CompletionOptions : public Data
+        {
+          public:
+            CompletionOptions( const Data& data );
+
+            CompletionOptions( void );
+
+            u1 hasResolveProvider( void ) const;
+
+            u1 resolveProvider( void ) const;
+
+            void setResolveProvider( const u1 resolveProvider );
+
+            u1 hasTriggerCharacters( void ) const;
+
+            Data triggerCharacters( void ) const;
+
+            void addTriggerCharacters( const std::string& triggerCharacter );
+
+            static void validate( const Data& data );
+        };
+
+        class SignatureHelpOptions : public Data
+        {
+          public:
+            SignatureHelpOptions( const Data& data );
+
+            SignatureHelpOptions( void );
+
+            u1 hasTriggerCharacters( void ) const;
+
+            Data triggerCharacters( void ) const;
+
+            void addTriggerCharacters( const std::string& triggerCharacter );
+
+            static void validate( const Data& data );
+        };
+
+        class CodeLensOptions : public Data
+        {
+          public:
+            CodeLensOptions( const Data& data );
+
+            CodeLensOptions( void );
+
+            u1 hasResolveProvider( void ) const;
+
+            u1 resolveProvider( void ) const;
+
+            void setResolveProvider( const u1 resolveProvider );
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentOnTypeFormattingOptions : public Data
+        {
+          public:
+            DocumentOnTypeFormattingOptions( const Data& data );
+
+            DocumentOnTypeFormattingOptions( const std::string& firstTriggerCharacter );
+
+            std::string firstTriggerCharacter( void ) const;
+
+            u1 hasMoreTriggerCharacter( void ) const;
+
+            Data moreTriggerCharacter( void ) const;
+
+            void addMoreTriggerCharacter( const Data& moreTriggerCharacter );
+
+            static void validate( const Data& data );
+        };
+
+        class RenameOptions : public Data
+        {
+          public:
+            RenameOptions( const Data& data );
+
+            u1 hasPrepareProvider( void ) const;
+
+            u1 prepareProvider( void ) const;
+
+            void setPrepareProvider( const u1 prepareProvider );
+
+            static void validate( const Data& data );
+        };
+
+        using DocumentLinkOptions = CodeLensOptions;
+
+        class ExecuteCommandOptions : public Data
+        {
+          public:
+            ExecuteCommandOptions( const Data& data );
+
+            ExecuteCommandOptions( void );
+
+            u1 hasCommands( void ) const;
+
+            Data commands( void ) const;
+
+            void addCommand( const std::string& command );
+
+            static void validate( const Data& data );
+        };
+        class StaticRegistrationOptions : public Data
+        {
+          public:
+            StaticRegistrationOptions( const Data& data );
+
+            u1 hasId( void ) const;
+
+            std::string id( void ) const;
+
+            void setId( std::string id );
+
+            static void validate( const Data& data );
+        };
+
+        class TextDocumentRegistrationOptions : public Data
+        {
+          public:
+            TextDocumentRegistrationOptions( const Data& data );
+
+            TextDocumentRegistrationOptions( const DocumentSelector& documentSelector );
+
+            DocumentSelector documentSelector( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class TypeDefinitionProvider : public Data
+        {
+          public:
+            TypeDefinitionProvider( const Data& data );
+
+            DocumentSelector documentSelector( void ) const;
+
+            u1 hasId( void ) const;
+
+            std::string id( void ) const;
+
+            void setId( std::string id );
+
+            static void validate( const Data& data );
+        };
+
+        using ImplementationProvider = TypeDefinitionProvider;
+
+        class ColorProviderOptions : public Data
+        {
+          public:
+            ColorProviderOptions( const Data& data );
+
+            static void validate( const Data& data );
+        };
+
+        using FoldingRangeProviderOptions = ColorProviderOptions;
+
+        class ColorProvider : public Data
+        {
+          public:
+            ColorProvider( const Data& data );
+
+            DocumentSelector documentSelector( void ) const;
+
+            u1 hasId( void ) const;
+
+            std::string id( void ) const;
+
+            void setId( std::string id );
+
+            static void validate( const Data& data );
+        };
+
+        using FoldingRangeProvider = ColorProvider;
+
+        class Workspace : public Data
+        {
+          public:
+            Workspace( const Data& data );
+
+            static void validate( const Data& data );
+
+            class WorkspaceFolders : public Data
             {
               public:
-                CompletionList( const Data& data );
+                WorkspaceFolders( const Data& data );
 
-                CompletionList( const u1 isIncomplete, const CompletionItems& items );
+                u1 supported( void ) const;
 
-                CompletionItems items( void ) const;
+                u1 hasSupported( void ) const;
 
-                u1 isIncomplete( void ) const;
+                void setSupported( const u1 supported );
 
-                static void validate( const Data& data );
-            };
+                void setChangeNotifications( const std::string& changeNotifications );
 
-            using CompletionResolveResult = CompletionItem;
+                void setChangeNotifications( const u1 changeNotifications );
 
-            using SignatureHelpParams = TextDocumentPositionParams;
+                u1 hasChangeNotifications( void ) const;
 
-            class CompletionResult : public Data
-            {
-              public:
-                CompletionResult( void );
-
-                CompletionResult( const Data& data );
-
-                CompletionResult( const CompletionList& list );
-
-                CompletionResult( const CompletionItems& items );
+                std::string changeNotifications( void ) const;
 
                 static void validate( const Data& data );
             };
+            WorkspaceFolders workspaceFolders( void ) const;
 
-            class ParameterInformation : public Data
-            {
-              public:
-                ParameterInformation( const Data& data );
+            u1 hasWorkspaceFolders( void ) const;
 
-                ParameterInformation( const std::string& label );
+            void setWorkspaceFolders( const WorkspaceFolders& workspaceFolders );
+        };
+        class ServerCapabilities : public Data
+        {
+          public:
+            ServerCapabilities( const Data& data );
 
-                std::string label( void ) const;
+            ServerCapabilities( void );
 
-                MarkupContent documentation( void ) const;
+            u1 hasTextDocumentSync( void ) const;
 
-                u1 hasDocumentation( void ) const;
+            TextDocumentSyncOptions textDocumentSync( void ) const;
 
-                void setDocumentation( const MarkupContent& doc );
+            void setTextDocumentSync( const TextDocumentSyncOptions& textDocumentSync );
 
-                static void validate( const Data& data );
-            };
+            void setTextDocumentSync( const TextDocumentSyncKind& textDocumentSync );
 
-            using ParameterInformations = std::vector< ParameterInformation >;
-            class SignatureInformation : public Data
-            {
-              public:
-                SignatureInformation( const Data& data );
+            u1 hasHoverProvider( void ) const;
 
-                SignatureInformation( const std::string& label );
+            u1 hoverProvider( void ) const;
 
-                std::string label( void ) const;
+            void setHoverProvider( const u1 hoverProvider );
 
-                MarkupContent documentation( void ) const;
+            u1 hasCompletionProvider( void ) const;
 
-                u1 hasDocumentation( void ) const;
+            CompletionOptions completionProvider( void ) const;
 
-                void setDocumentation( const MarkupContent& doc );
+            void setCompletionProvider( const CompletionOptions& completionProvider );
 
-                u1 hasParameters( void ) const;
+            u1 hasSignatureHelpProvider( void ) const;
 
-                ParameterInformations parameters( void ) const;
+            SignatureHelpOptions signatureHelpProvider( void ) const;
 
-                void setParameters( const ParameterInformations& parameters );
+            void setSignatureHelpProvider( const SignatureHelpOptions& signatureHelpProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasDefinitionProvider( void ) const;
 
-            using SignatureInformations = std::vector< SignatureInformation >;
-            class SignatureHelp : public Data
-            {
-              public:
-                SignatureHelp( const Data& data );
+            u1 definitionProvider( void ) const;
 
-                SignatureHelp( const SignatureInformations& signatures );
+            void setDefinitionProvider( const u1 definitionProvider );
 
-                SignatureInformations signatures( void ) const;
+            u1 hasTypeDefinitionProvider( void ) const;
 
-                u1 hasActiveSignature( void ) const;
+            TypeDefinitionProvider typeDefinitionProvider( void ) const;
 
-                void setActiveSignature( const std::size_t activeSignature );
+            void setTypeDefinitionProvider( const TypeDefinitionProvider& typeDefinitionProvider );
 
-                std::size_t activeSignature( void ) const;
+            u1 hasImplementationProvider( void ) const;
 
-                u1 hasActiveParameter( void ) const;
+            ImplementationProvider implementationProvider( void ) const;
 
-                void setActiveParameter( const std::size_t activeParameter );
+            void setImplementationProvider( const ImplementationProvider& implementationProvider );
 
-                std::size_t activeParameter( void ) const;
+            u1 hasReferencesProvider( void ) const;
 
-                static void validate( const Data& data );
-            };
+            u1 referencesProvider( void ) const;
 
-            class SignatureHelpResult : public Data
-            {
-              public:
-                SignatureHelpResult( void );
+            void setReferencesProvider( const u1 referencesProvider );
 
-                SignatureHelpResult( const Data& data );
+            u1 hasDocumentHighlightProvider( void ) const;
 
-                SignatureHelpResult( const SignatureHelp& signature );
+            u1 documentHighlightProvider( void ) const;
 
-                static void validate( const Data& data );
-            };
+            void setDocumentHighlightProvider( const u1 documentHighlightProvider );
 
-            using TypeDefinitionParams = TextDocumentPositionParams;
+            u1 hasDocumentSymbolProvider( void ) const;
 
-            using Locations = std::vector< Location >;
+            u1 documentSymbolProvider( void ) const;
 
-            class LocationLink : public Data
-            {
-              public:
-                LocationLink( const Data& data );
+            void setDocumentSymbolProvider( const u1 documentSymbolProvider );
 
-                LocationLink( const DocumentUri& targetUri, const Range& targetRange );
+            u1 hasWorkspaceSymbolProvider( void ) const;
 
-                DocumentUri targetUri( void ) const;
+            u1 workspaceSymbolProvider( void ) const;
 
-                Range targetRange( void ) const;
+            void setWorkspaceSymbolProvider( const u1 workspaceSymbolProvider );
 
-                u1 hasOriginSelectionRange( void ) const;
+            u1 hasCodeActionProvider( void ) const;
 
-                void setOriginSelectionRange( const Range& range );
+            u1 codeActionProvider( void ) const;
 
-                Range originSelectionRange( void ) const;
+            void setCodeActionProvider( const u1 codeActionProvider );
 
-                u1 hasTargetSelectionRange( void ) const;
+            u1 hasCodeLensProvider( void ) const;
 
-                void setTargetSelectionRange( const Range& range );
+            CodeLensOptions codeLensProvider( void ) const;
 
-                Range targetSelectionRange( void ) const;
+            void setCodeLensProvider( const CodeLensOptions& codeLensProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasDocumentFormattingProvider( void ) const;
 
-            using LocationLinks = std::vector< LocationLink >;
+            u1 documentFormattingProvider( void ) const;
 
-            class TypeDefinitionResult : public Data
-            {
-              public:
-                TypeDefinitionResult( const Data& data );
+            void setDocumentFormattingProvider( const u1 documentFormattingProvider );
 
-                TypeDefinitionResult( const Locations& locations );
+            u1 hasDocumentRangeFormattingProvider( void ) const;
 
-                TypeDefinitionResult( const LocationLinks& locationLinks );
+            u1 documentRangeFormattingProvider( void ) const;
 
-                TypeDefinitionResult( const Location& location );
+            void setDocumentRangeFormattingProvider( const u1 documentRangeFormattingProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasDocumentOnTypeFormattingProvider( void ) const;
 
-            using TextDocumentImplementationResult = TypeDefinitionResult;
+            DocumentOnTypeFormattingOptions documentOnTypeFormattingProvider( void ) const;
 
-            using TextDocumentImplementationParams = TextDocumentPositionParams;
+            void setDocumentOnTypeFormattingProvider(
+                const DocumentOnTypeFormattingOptions& documentOnTypeFormattingProvider );
 
-            class ReferenceContext : public Data
-            {
-              public:
-                ReferenceContext( const Data& data );
+            u1 hasRenameProvider( void ) const;
 
-                ReferenceContext( const u1 includeDeclaration );
+            u1 renameProvider( void ) const;
 
-                u1 includeDeclaration( void ) const;
+            void setRenameProvider( const u1 renameProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasDocumentLinkProvider( void ) const;
 
-            class ReferenceParams : public TextDocumentPositionParams
-            {
-              public:
-                ReferenceParams( const Data& data );
+            DocumentLinkOptions documentLinkProvider( void ) const;
 
-                ReferenceParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const Position& position,
-                    const ReferenceContext& context );
+            void setDocumentLinkProvider( const DocumentLinkOptions& documentLinkProvider );
 
-                ReferenceContext context( void ) const;
+            u1 hasColorProvider( void ) const;
 
-                static void validate( const Data& data );
-            };
-            class ReferenceResult : public Data
-            {
-              public:
-                ReferenceResult( const Data& data );
+            ColorProvider colorProvider( void ) const;
 
-                ReferenceResult( const Locations& locations );
+            void setColorProvider( const ColorProvider& colorProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasFoldingRangeProvider( void ) const;
 
-            enum class CodeActionKind
-            {
-                QuickFix,
-                Refactor,
-                RefactorExtract,
-                RefactorInline,
-                RefactorRewrite,
-                Source,
-                SourceOrganizeImports
-            };
+            FoldingRangeProvider foldingRangeProvider( void ) const;
 
-            class CodeActionOptions : public Data
-            {
-              public:
-                CodeActionOptions( const Data& data );
+            void setFoldingRangeProvider( const FoldingRangeProvider& foldingRangeProvider );
 
-                u1 hasCodeActionKinds( void ) const;
+            u1 hasExecuteCommandProvider( void ) const;
 
-                void addCodeActionKind( CodeActionKind kind );
+            ExecuteCommandOptions executeCommandProvider( void ) const;
 
-                std::vector< std::string > codeActionKinds( void ) const;
+            void setExecuteCommandProvider( const ExecuteCommandOptions& executeCommandProvider );
 
-                static void validate( const Data& data );
-            };
+            u1 hasExperimental( void ) const;
 
-            using Diagnostics = std::vector< Diagnostic >;
+            Data experimental( void ) const;
 
-            class CodeActionContext : public Data
-            {
-              public:
-                CodeActionContext( const Data& data );
+            void setExperimental( const Data& experimental );
 
-                CodeActionContext( const Diagnostics& diagnostics );
+            u1 hasWorkspace( void ) const;
 
-                Diagnostics diagnostics( void ) const;
+            void setWorkspace( const Workspace& workspace );
 
-                u1 hasKind( void ) const;
+            Workspace workspace( void ) const;
 
-                void setKind( const CodeActionKind kind );
+            static void validate( const Data& data );
+        };
 
-                std::string kind( void ) const;
+        class WorkspaceFolder : public Data
+        {
+          public:
+            WorkspaceFolder( const std::string& uri, const std::string& name );
 
-                static void validate( const Data& data );
-            };
+            WorkspaceFolder( const Data& data );
 
-            class CodeActionParams : public Data
-            {
-              public:
-                CodeActionParams( const Data& data );
+            std::string uri( void ) const;
 
-                CodeActionParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const Range& range,
-                    const CodeActionContext& context );
+            std::string name( void ) const;
 
-                TextDocumentIdentifier textDocument( void ) const;
+            static void validate( const Data& data );
+        };
 
-                Range range( void ) const;
+        using WorkspaceFolders = std::vector< WorkspaceFolder >;
 
-                CodeActionContext context( void ) const;
+        class InitializeParams : public Data
+        {
+          public:
+            InitializeParams( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            InitializeParams(
+                const std::size_t processId,
+                const DocumentUri& rootUri,
+                const ClientCapabilities& capabilities );
 
-            class CodeAction : public Data
-            {
-              public:
-                CodeAction( const Data& data );
+            std::size_t processId( void ) const;
 
-                CodeAction( const std::string& title );
+            // rootPath interface omitted!
 
-                std::string title( void ) const;
+            DocumentUri rootUri( void ) const;
 
-                u1 hasKind( void ) const;
+            u1 hasInitializationOptions( void ) const;
 
-                std::string kind( void ) const;
+            Data initializationOptions( void ) const;
 
-                void setKind( const CodeActionKind kind );
+            void setInitializationOptions( const Data& initializationOptions );
 
-                u1 hasDiagnostics( void ) const;
+            ClientCapabilities capabilities( void ) const;
 
-                Diagnostics diagnostics( void ) const;
+            u1 hasTrace( void ) const;
 
-                void addDiagnostic( const Diagnostic& diagnostic );
+            std::string trace( void ) const;
 
-                u1 hasEdit( void ) const;
+            void setTrace( const std::string& trace );
 
-                WorkspaceEdit edit( void ) const;
+            WorkspaceFolders workspaceFolders( void ) const;
 
-                void setEdit( const WorkspaceEdit& edit );
+            u1 hasWorkspaceFolders( void ) const;
 
-                void setCommand( const Command& command );
+            void addWorkspaceFolder( WorkspaceFolder folder );
 
-                u1 hasCommand( void ) const;
+            static void validate( const Data& data );
+        };
 
-                Command command( void ) const;
+        class InitializeResult : public Data
+        {
+          public:
+            InitializeResult( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            InitializeResult( const ServerCapabilities& capabilities );
 
-            class CodeActionResult : public Data
-            {
-              public:
-                CodeActionResult( const Data& data );
+            ServerCapabilities capabilities( void ) const;
 
-                CodeActionResult( const std::vector< Command >& commands );
+            static void validate( const Data& data );
+        };
 
-                CodeActionResult( void );
+        class InitializeError : public Data
+        {
+          public:
+            InitializeError( const Data& data );
 
-                void addCommand( const Command& command );
+            InitializeError( const u1 retry );
 
-                static void validate( const Data& data );
-            };
+            u1 retry( void ) const;
 
-            class CodeActionRegistrationOptions
-            : public TextDocumentRegistrationOptions
-            , public CodeActionOptions
-            {
-            };
+            static void validate( const Data& data );
+        };
 
-            class PublishDiagnosticsParams : public Data
-            {
-              public:
-                PublishDiagnosticsParams( const Data& data );
+        enum class MessageType
+        {
+            Error = 1,
 
-                PublishDiagnosticsParams(
-                    const DocumentUri& uri, const std::vector< Diagnostic >& diagnostics );
+            Warning = 2,
 
-                DocumentUri uri( void ) const;
+            Info = 3,
 
-                Data diagnostics( void ) const;
+            Log = 4
+        };
 
-                static void validate( const Data& data );
-            };
+        class CancelParams : public Data
+        {
+          public:
+            CancelParams( const Data& data );
 
-            using HoverParams = TextDocumentPositionParams;
+            CancelParams( const std::size_t& id );
 
-            class MarkedString : public Data
-            {
-              public:
-                MarkedString( const Data& data );
+            CancelParams( const std::string& id );
 
-                MarkedString( const std::string& language, const std::string& value );
+            std::string id( void ) const;
 
-                std::string language( void ) const;
+            static void validate( const Data& data );
+        };
 
-                std::string value( void ) const;
+        class ShowMessageParams : public Data
+        {
+          public:
+            ShowMessageParams( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            ShowMessageParams( const MessageType type, const std::string& message );
 
-            class HoverResult : public Data
-            {
-              public:
-                HoverResult( const Data& data );
+            MessageType messageType( void ) const;
 
-                HoverResult( const std::vector< MarkedString >& contents = {} );
+            std::string message( void ) const;
 
-                Data contents( void ) const;
+            static void validate( const Data& data );
+        };
 
-                void addContent( const MarkedString& content );
+        class MessageActionItem : public Data
+        {
+          public:
+            MessageActionItem( const Data& data );
 
-                u1 hasRange( void ) const;
+            MessageActionItem( const std::string& title );
 
-                Range range( void ) const;
+            std::string title( void ) const;
 
-                void setRange( const Range& range );
+            static void validate( const Data& data );
+        };
 
-                static void validate( const Data& data );
-            };
+        class ShowMessageRequestResult : public Data
+        {
+          public:
+            ShowMessageRequestResult( void );
 
-            using DefinitionParams = TextDocumentPositionParams;
+            ShowMessageRequestResult( const Data& data );
 
-            class DefinitionResult : public Data
-            {
-              public:
-                DefinitionResult( const Data& data );
+            ShowMessageRequestResult( const MessageActionItem& item );
 
-                DefinitionResult( const Location& location );
+            ShowMessageRequestResult( const std::string& title );
 
-                DefinitionResult( const std::vector< Location > locations );
+            static void validate( const Data& data );
+        };
 
-                Data locations( void ) const;
+        using MessageActionItems = std::vector< MessageActionItem >;
 
-                static void validate( const Data& data );
-            };
+        class ShowMessageRequestParams : public Data
+        {
+          public:
+            ShowMessageRequestParams( const Data& data );
 
-            using DocumentHighlightParams = TextDocumentPositionParams;
+            ShowMessageRequestParams( const MessageType type, const std::string& message );
 
-            enum class DocumentHighlightKind
-            {
-                Text = 1,
-                Read = 2,
-                Write = 3
-            };
+            MessageType messageType( void ) const;
 
-            class DocumentHighlight : public Data
-            {
-              public:
-                DocumentHighlight( const Data& data );
+            u1 hasActions( void );
 
-                DocumentHighlight( const Range& range );
+            MessageActionItems actions( void ) const;
 
-                Range range( void ) const;
+            void addAction( const MessageActionItem& action );
 
-                u1 hasKind( void ) const;
+            std::string message( void ) const;
 
-                DocumentHighlightKind kind( void ) const;
+            static void validate( const Data& data );
+        };
 
-                void setKind( const DocumentHighlightKind kind );
+        using LogMessageParams = ShowMessageParams;
 
-                static void validate( const Data& data );
-            };
-            using DocumentHighlights = std::vector< DocumentHighlight >;
+        class TelemetryEventParams : public Data
+        {
+          public:
+            TelemetryEventParams( const Data& data );
 
-            class DocumentHighlightResult : public Data
-            {
-              public:
-                DocumentHighlightResult( void );
+            static void validate( const Data& data );
+        };
 
-                DocumentHighlightResult( const Data& data );
+        class Registration : public Data
+        {
+          public:
+            Registration( const Data& data );
 
-                DocumentHighlightResult( const DocumentHighlights& highlights );
+            Registration( const std::string& id, const std::string& method );
 
-                static void validate( const Data& data );
-            };
+            std::string id( void ) const;
 
-            class DocumentSymbolParams : public Data
-            {
-              public:
-                DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
+            std::string method( void ) const;
 
-                DocumentSymbolParams( const Data& data );
+            Data registerOptions( void ) const;
 
-                TextDocumentIdentifier textDocument( void ) const;
+            u1 hasRegisterOptions( void ) const;
 
-                static void validate( const Data& data );
-            };
+            void addRegisterOption( const Data& option );
 
-            class DocumentSymbol;
+            static void validate( const Data& data );
+        };
 
-            using DocumentSymbols = std::vector< DocumentSymbol >;
+        using Registrations = std::vector< Registration >;
 
-            class DocumentSymbol : public Data
-            {
-              public:
-                DocumentSymbol( const Data& data );
+        class RegistrationParams : public Data
+        {
+          public:
+            RegistrationParams( const Data& data );
 
-                DocumentSymbol(
-                    const std::string& name,
-                    const SymbolKind kind,
-                    Range range,
-                    Range selectionRange );
+            RegistrationParams( const Registrations& registrations );
 
-                std::string name( void ) const;
+            Registrations registrations( void ) const;
 
-                SymbolKind kind( void ) const;
+            static void validate( const Data& data );
+        };
 
-                Range range( void ) const;
+        class TextDocumentChangeRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            TextDocumentChangeRegistrationOptions( const Data& data );
 
-                Range selectionRange( void ) const;
+            TextDocumentChangeRegistrationOptions(
+                const DocumentSelector& documentSelector, TextDocumentSyncKind kind );
 
-                u1 hasDetail( void ) const;
+            TextDocumentSyncKind kind( void ) const;
 
-                void setDetail( const std::string& detail );
+            static void validate( const Data& data );
+        };
 
-                std::string detail( void ) const;
+        class TextDocumentSaveRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            TextDocumentSaveRegistrationOptions( const Data& data );
 
-                u1 hasDeprecated( void ) const;
+            TextDocumentSaveRegistrationOptions( const DocumentSelector& documentSelector );
 
-                u1 deprecated( void ) const;
+            u1 hasIncludeText( void ) const;
 
-                void setDeprecated( const u1 deprecated );
+            void setIncludeText( const u1 includeText );
 
-                u1 hasChildren( void ) const;
+            u1 includeText( void ) const;
 
-                DocumentSymbols children( void ) const;
+            static void validate( const Data& data );
+        };
 
-                void addChild( const DocumentSymbol& symbol );
+        using TriggerCharacters = std::vector< std::string >;
 
-                static void validate( const Data& data );
-            };
+        class SignatureHelpRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            SignatureHelpRegistrationOptions( const Data& data );
 
-            class DocumentSymbolResult : public Data
-            {
-              public:
-                DocumentSymbolResult( void );
+            SignatureHelpRegistrationOptions( const DocumentSelector& documentSelector );
 
-                DocumentSymbolResult( const Data& data );
+            u1 hasTriggerCharacters( void ) const;
 
-                DocumentSymbolResult( const DocumentSymbols& symbols );
+            void setTriggerCharacters( const TriggerCharacters& triggerCharacters );
 
-                DocumentSymbolResult( const SymbolInformations& information );
+            void addTriggerCharacter( const std::string& triggerCharacter );
 
-                static void validate( const Data& data );
-            };
+            TriggerCharacters triggerCharacters( void ) const;
 
-            class CodeLensParams : public Data
-            {
-              public:
-                CodeLensParams( const Data& data );
+            static void validate( const Data& data );
+        };
 
-                CodeLensParams( const TextDocumentIdentifier& textDocument );
+        class Unregistration : public Data
+        {
+          public:
+            Unregistration( const Data& data );
 
-                TextDocumentIdentifier textDocument( void ) const;
+            Unregistration( const std::string& id, const std::string& method );
 
-                static void validate( const Data& data );
-            };
+            std::string id( void ) const;
 
-            class CodeLens : public Data
-            {
-              public:
-                CodeLens( const Data& data );
+            std::string method( void ) const;
 
-                CodeLens( const Range& range );
+            static void validate( const Data& data );
+        };
+        using Unregistrations = std::vector< Unregistration >;
 
-                Range range( void ) const;
+        class UnregistrationParams : public Data
+        {
+          public:
+            UnregistrationParams( const std::vector< Unregistration >& unregistrations );
 
-                u1 hasCommand( void ) const;
+            UnregistrationParams( const Data& data );
 
-                Command command( void ) const;
+            Unregistrations unregistrations( void ) const;
 
-                void setCommand( const Command& command );
+            static void validate( const Data& data );
+        };
 
-                u1 hasData( void ) const;
+        class WorkspaceFoldersResult : public Data
+        {
+          public:
+            WorkspaceFoldersResult();
 
-                Data data( void ) const;
+            WorkspaceFoldersResult( const Data& data );
 
-                void setData( const Data& data );
+            WorkspaceFoldersResult( const WorkspaceFolders& workspaceFolders );
 
-                static void validate( const Data& data );
-            };
+            WorkspaceFolders toVec( void ) const;
 
-            class CodeLensResult : public Data
-            {
-              public:
-                CodeLensResult( const Data& data );
+            static void validate( const Data& data );
+        };
 
-                CodeLensResult( const std::vector< CodeLens >& codeLens = {} );
+        class WorkspaceFoldersChangeEvent : public Data
+        {
+          public:
+            WorkspaceFoldersChangeEvent(
+                const WorkspaceFolders& added, const WorkspaceFolders& removed );
 
-                void addCodeLens( const CodeLens& codeLens );
+            WorkspaceFoldersChangeEvent( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            WorkspaceFolders added( void ) const;
 
-            class DocumentLinkParams : public Data
-            {
-              public:
-                DocumentLinkParams( const Data& data );
+            WorkspaceFolders removed( void ) const;
 
-                DocumentLinkParams( const TextDocumentIdentifier& textDocument );
+            static void validate( const Data& data );
+        };
 
-                TextDocumentIdentifier textDocument( void ) const;
+        class DidChangeWorkspaceFoldersParams : public Data
+        {
+          public:
+            DidChangeWorkspaceFoldersParams( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            DidChangeWorkspaceFoldersParams( const WorkspaceFoldersChangeEvent& event );
 
-            class DocumentLink : public Data
-            {
-              public:
-                DocumentLink( const Data& data );
+            WorkspaceFoldersChangeEvent event( void ) const;
 
-                DocumentLink( const Range& range );
+            static void validate( const Data& data );
+        };
 
-                Range range( void ) const;
+        using DidChangeConfigurationSettings = Data;
 
-                u1 hasTarget( void ) const;
+        class DidChangeConfigurationParams : public Data
+        {
+          public:
+            DidChangeConfigurationParams( const DidChangeConfigurationSettings& settings );
 
-                void setTarget( const DocumentUri& target );
+            DidChangeConfigurationSettings settings( void ) const;
 
-                DocumentUri target( void ) const;
+            static void validate( const Data& data );
+        };
 
-                u1 hasData( void ) const;
+        class ConfigurationItem : public Data
+        {
+          public:
+            ConfigurationItem( const Data& data );
 
-                void setData( const Data& data );
+            ConfigurationItem( const std::string& scopeUri, const std::string& section );
 
-                Data data( void ) const;
+            u1 hasScopeUri( void ) const;
 
-                static void validate( const Data& data );
-            };
-            using DocumentLinks = std::vector< DocumentLink >;
-            class DocumentLinkResult : public Data
-            {
-              public:
-                DocumentLinkResult( void );
+            u1 hasSection( void ) const;
 
-                DocumentLinkResult( const Data& data );
+            std::string scopeUri( void ) const;
 
-                DocumentLinkResult( const DocumentLinks links );
+            std::string section( void ) const;
 
-                static void validate( const Data& data );
-            };
+            void setSection( const std::string& section );
 
-            using CodeLensResolveParams = CodeLens;
-            using CodeLensResolveResult = CodeLens;
-            using DocumentLinkResolveResult = DocumentLink;
-            using DocumentLinkResolveParams = DocumentLink;
+            void setScopeUri( const std::string& uri );
 
-            class DocumentColorParams : public Data
-            {
-              public:
-                DocumentColorParams( const Data& data );
+            static void validate( const Data& data );
+        };
 
-                DocumentColorParams( const TextDocumentIdentifier& textDocument );
+        class ConfigurationResult : public Data
+        {
+          public:
+            ConfigurationResult( void );
 
-                TextDocumentIdentifier textDocument( void ) const;
+            ConfigurationResult( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            static void validate( const Data& data );
+        };
 
-            class Color : public Data
-            {
-              public:
-                Color( const Data& data );
+        using ConfigurationItems = std::vector< ConfigurationItem >;
 
-                Color( const float red, const float green, const float blue, const float alpha );
+        class ConfigurationParams : public Data
+        {
+          public:
+            ConfigurationParams( const ConfigurationItems& items );
 
-                float red( void ) const;
+            ConfigurationParams( const Data& data );
 
-                float green( void ) const;
+            ConfigurationItems items( void ) const;
 
-                float blue( void ) const;
+            static void validate( const Data& data );
+        };
 
-                float alpha( void ) const;
+        enum class FileChangeType
+        {
+            Created = 1,
 
-                static void validate( const Data& data );
-            };
+            Changed = 2,
 
-            class ColorInformation : public Data
-            {
-              public:
-                ColorInformation( const Data& data );
+            Deleted = 3
+        };
 
-                ColorInformation( const Range& range, const Color& color );
+        /**
+          An event describing a file change.
+         */
+        class FileEvent : public Data
+        {
+          public:
+            FileEvent( const Data& data );
 
-                Range range( void ) const;
+            FileEvent( const DocumentUri& uri, const FileChangeType type );
 
-                Color color( void ) const;
+            DocumentUri documentUri( void ) const;
 
-                static void validate( const Data& data );
-            };
-            using ColorInformations = std::vector< ColorInformation >;
+            FileChangeType type( void ) const;
 
-            class DocumentColorResult : public Data
-            {
-              public:
-                DocumentColorResult( const Data& data );
+            static void validate( const Data& data );
+        };
 
-                DocumentColorResult( const ColorInformations& colorInformations );
+        using FileEvents = std::vector< FileEvent >;
 
-                static void validate( const Data& data );
-            };
+        class DidChangeWatchedFilesParams : public Data
+        {
+          public:
+            DidChangeWatchedFilesParams( const FileEvents& changes );
 
-            class ColorPresentationParams : public DocumentColorParams
-            {
-              public:
-                ColorPresentationParams( const Data& data );
+            DidChangeWatchedFilesParams( const Data& data );
 
-                ColorPresentationParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const Color& color,
-                    const Range& range );
+            FileEvents changes( void ) const;
 
-                Color color( void ) const;
+            static void validate( const Data& data );
+        };
 
-                Range range( void ) const;
+        enum class WatchKind
+        {
 
-                static void validate( const Data& data );
-            };
+            Create = 1,
 
-            class ColorPresentation : public Data
-            {
-              public:
-                ColorPresentation( const Data& data );
+            Change = 2,
 
-                ColorPresentation( const std::string& label );
+            Delete = 4
+        };
 
-                std::string label( void ) const;
+        class FileSystemWatcher : public Data
+        {
+          public:
+            FileSystemWatcher( const Data& data );
 
-                u1 hasTextEdit( void ) const;
+            FileSystemWatcher( const std::string& globPattern );
 
-                void setTextEdit( const TextEdit& textEdit );
+            FileSystemWatcher( const std::string& globPattern, const WatchKind kind );
 
-                TextEdit textEdit( void ) const;
+            std::string globPattern( void );
 
-                u1 hasAdditionalTextEdits( void ) const;
+            u1 hasKind( void ) const;
 
-                void addAdditionalTextEdit( const TextEdit& textEdit );
+            WatchKind kind( void ) const;
 
-                TextEdits additionalTextEdits( void ) const;
+            static void validate( const Data& data );
 
-                static void validate( const Data& data );
-            };
+            void setKind( const WatchKind kind );
+        };
 
-            using ColorPresentations = std::vector< ColorPresentation >;
+        /**
+          Describe options to be used when registering for text document change events.
+         */
+        using FileSystemWatchers = std::vector< FileSystemWatcher >;
+        class DidChangeWatchedFilesRegistrationOptions : public Data
+        {
+          public:
+            DidChangeWatchedFilesRegistrationOptions( const FileSystemWatchers& watchers );
 
-            class ColorPresentationResult : public Data
-            {
-              public:
-                ColorPresentationResult( const Data& data );
+            DidChangeWatchedFilesRegistrationOptions( const Data& data );
 
-                ColorPresentationResult( ColorPresentations presentations );
+            FileSystemWatchers watchers( void ) const;
 
-                static void validate( const Data& data );
-            };
+            static void validate( const Data& data );
+        };
 
-            class FormattingOptions : public Data
-            {
-              private:
-                static void validateAdditionalOptions( const Data& data );
+        class WorkspaceSymbolParams : public Data
+        {
+          public:
+            WorkspaceSymbolParams( const Data& data );
 
-              public:
-                FormattingOptions( const Data& data );
+            WorkspaceSymbolParams( const std::string& query );
 
-                FormattingOptions( const std::size_t tabSize, const u1 insertSpaces );
+            std::string query( void ) const;
 
-                std::size_t tabSize( void ) const;
+            static void validate( const Data& data );
+        };
 
-                void addBool( const std::string& key, const u1 boolean );
+        enum class SymbolKind
+        {
+            File = 1,
+            Module = 2,
+            Namespace = 3,
+            Package = 4,
+            Class = 5,
+            Method = 6,
+            Property = 7,
+            Field = 8,
+            Constructor = 9,
+            Enum = 10,
+            Interface = 11,
+            Function = 12,
+            Variable = 13,
+            Constant = 14,
+            String = 15,
+            Number = 16,
+            Boolean = 17,
+            Array = 18,
+            Object = 19,
+            Key = 20,
+            Null = 21,
+            EnumMember = 22,
+            Struct = 23,
+            Event = 24,
+            Operator = 25,
+            TypeParameter = 26
+        };
 
-                void addNumber( const std::string& key, const float number );
+        class SymbolInformation : public Data
+        {
+          public:
+            SymbolInformation(
+                const std::string& name, const SymbolKind kind, const Location& location );
 
-                void addString( const std::string& key, const std::string& string );
+            SymbolInformation( const Data& data );
 
-                u1 insertSpaces( void ) const;
+            u1 isDeprecated( void ) const;
 
-                static void validate( const Data& data );
-            };
+            u1 hasDeprecated( void ) const;
 
-            class DocumentFormattingParams : public Data
-            {
-              public:
-                DocumentFormattingParams( const Data& data );
+            void setDeprecated( const u1 deprecated );
 
-                DocumentFormattingParams(
-                    const TextDocumentIdentifier& textDocument, const FormattingOptions& options );
+            std::string containerName( void ) const;
 
-                TextDocumentIdentifier textDocument( void ) const;
+            u1 hasContainerName( void ) const;
 
-                FormattingOptions options( void ) const;
+            void setContainerName( const std::string& containerName );
 
-                static void validate( const Data& data );
-            };
+            Location location( void ) const;
 
-            class DocumentFormattingResult : public Data
-            {
-              public:
-                DocumentFormattingResult( void );
+            std::string name( void ) const;
 
-                DocumentFormattingResult( const Data& data );
+            SymbolKind kind( void ) const;
 
-                DocumentFormattingResult( const TextEdits& edits );
+            static void validate( const Data& data );
+        };
+        using SymbolInformations = std::vector< SymbolInformation >;
+        class WorkspaceSymbolResult : public Data
+        {
+          public:
+            WorkspaceSymbolResult( const Data& data );
 
-                static void validate( const Data& data );
-            };
-            class DocumentRangeFormattingParams : public DocumentFormattingParams
-            {
-              public:
-                DocumentRangeFormattingParams( const Data& data );
+            WorkspaceSymbolResult( const std::vector< SymbolInformation >& symbolInformation );
 
-                DocumentRangeFormattingParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const Range& range,
-                    const FormattingOptions& options );
+            void addSymbolInformation( const SymbolInformation& information );
 
-                Range range( void ) const;
+            SymbolInformations symbolInformation( void ) const;
 
-                static void validate( const Data& data );
-            };
+            static void validate( const Data& data );
+        };
 
-            class DocumentOnTypeFormattingParams : public DocumentFormattingParams
-            {
-              public:
-                DocumentOnTypeFormattingParams( const Data& data );
+        class ApplyWorkspaceEditParams : public Data
+        {
+          public:
+            ApplyWorkspaceEditParams( const Data& data );
 
-                DocumentOnTypeFormattingParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const FormattingOptions& options,
-                    const Position& position,
-                    const std::string& ch );
+            ApplyWorkspaceEditParams( const WorkspaceEdit& edit );
 
-                Position position( void ) const;
+            WorkspaceEdit edit( void ) const;
 
-                std::string ch( void ) const;  // character that has been typed.
+            u1 hasLabel( void ) const;
 
-                static void validate( const Data& data );
-            };
+            std::string label( void ) const;
 
-            class DocumentOnTypeFormattingRegistrationOptions
-            : public TextDocumentRegistrationOptions
-            {
-              public:
-                DocumentOnTypeFormattingRegistrationOptions( const Data& data );
+            void setLabel( const std::string& label );
 
-                DocumentOnTypeFormattingRegistrationOptions(
-                    const DocumentSelector& documentSelector,
-                    const std::string& firstTriggerCharacter );
+            static void validate( const Data& data );
+        };
 
-                std::string firstTriggerCharacter( void ) const;
+        class ApplyWorkspaceEditResult : public Data
+        {
+          public:
+            ApplyWorkspaceEditResult( const Data& data );
 
-                u1 hasMoreTriggerCharacter( void ) const;
+            ApplyWorkspaceEditResult( const u1 applied );
 
-                void addMoreTriggerCharacter( const std::string& character );
+            u1 applied( void ) const;
 
-                std::vector< std::string > moreTriggerCharacter( void ) const;
+            static void validate( const Data& data );
+        };
 
-                static void validate( const Data& data );
-            };
+        class DidOpenTextDocumentParams : public Data
+        {
+          public:
+            DidOpenTextDocumentParams( const Data& data );
 
-            using DocumentOnTypeFormattingResult = DocumentFormattingResult;
+            DidOpenTextDocumentParams( const TextDocumentItem& textDocument );
 
-            using DocumentRangeFormattingResult = DocumentFormattingResult;
+            TextDocumentItem textDocument( void ) const;
 
-            class RenameParams : public Data
-            {
-              public:
-                RenameParams( const Data& data );
+            static void validate( const Data& data );
+        };
 
-                RenameParams(
-                    const TextDocumentIdentifier& textDocument,
-                    const Position& position,
-                    const std::string& newName );
+        class TextDocumentContentChangeEvent : public Data
+        {
+          public:
+            TextDocumentContentChangeEvent( const Data& data );
 
-                TextDocumentIdentifier textDocument( void ) const;
+            TextDocumentContentChangeEvent( const std::string& text );
 
-                Position position( void ) const;
+            u1 hasRange( void ) const;
 
-                std::string newName( void ) const;
+            Range range( void ) const;
 
-                static void validate( const Data& data );
-            };
+            void setRange( const Range& range );
 
-            class RenameRegistrationOptions : public TextDocumentRegistrationOptions
-            {
-              public:
-                RenameRegistrationOptions( const Data& data );
+            u1 hasRangeLength( void ) const;
 
-                RenameRegistrationOptions( const DocumentSelector& selector );
+            std::size_t rangeLength( void ) const;
 
-                u1 hasPrepareProvider( void ) const;
+            void setRangeLength( const std::size_t rangeLength );
 
-                void setPrepareProvider( const u1 prepareProvider );
+            std::string text( void ) const;
 
-                u1 prepareProvider( void ) const;
+            static void validate( const Data& data );
+        };
 
-                static void validate( const Data& data );
-            };
+        using TextDocumentContentChangeEvents = std::vector< TextDocumentContentChangeEvent >;
 
-            class RenameResult : public Data
-            {
-              public:
-                RenameResult( void );
+        class DidChangeTextDocumentParams : public Data
+        {
+          public:
+            DidChangeTextDocumentParams( const Data& data );
 
-                RenameResult( const Data& data );
+            DidChangeTextDocumentParams(
+                const VersionedTextDocumentIdentifier& textDocument,
+                const TextDocumentContentChangeEvents& contentChanges );
 
-                RenameResult( const WorkspaceEdit& edit );
+            VersionedTextDocumentIdentifier textDocument( void ) const;
 
-                static void validate( const Data& data );
-            };
+            TextDocumentContentChangeEvents contentChanges( void ) const;
 
-            using PrepareRenameParams = TextDocumentPositionParams;
+            static void validate( const Data& data );
+        };
 
-            class PrepareRenameResult : public Data
-            {
-              public:
-                PrepareRenameResult( void );
+        enum class TextDocumentSaveReason
+        {
+            Manual = 1,      // by the user pressing save, by starting debugging, or by an API call.
+            AfterDelay = 2,  // Automatic after a delay.
+            FocusOut = 3     //  When the editor lost focus.
+        };
 
-                PrepareRenameResult( const Data& data );
+        class WillSaveTextDocumentParams : public Data
+        {
+          public:
+            WillSaveTextDocumentParams( const Data& data );
 
-                PrepareRenameResult( const Range& range, const std::string& placeholder );
+            WillSaveTextDocumentParams(
+                const TextDocumentIdentifier& textDocument, TextDocumentSaveReason reason );
 
-                static void validate( const Data& data );
-            };
+            TextDocumentSaveReason reason( void ) const;
 
-            class FoldingRangeParams : public Data
-            {
-              public:
-                FoldingRangeParams( const Data& data );
+            TextDocumentIdentifier textDocument( void ) const;
 
-                FoldingRangeParams( const TextDocumentIdentifier& textDocument );
+            static void validate( const Data& data );
+        };
 
-                TextDocumentIdentifier textDocument( void ) const;
+        using TextEdits = std::vector< TextEdit >;
 
-                static void validate( const Data& data );
-            };
-            enum class FoldingRangeKind
-            {
-                Comment,
-                Imports,
-                Region
-            };
+        class WillSaveWaitUntilResponse : public Data
+        {
+          public:
+            WillSaveWaitUntilResponse( const Data& data );
 
-            class FoldingRange : public Data
-            {
-              public:
-                FoldingRange( const Data& data );
+            WillSaveWaitUntilResponse( const std::vector< TextEdit >& textEdit );
 
-                FoldingRange( const std::size_t startLine, const std::size_t endLine );
+            TextEdits textEdit( void ) const;
 
-                std::size_t startLine( void ) const;
+            static void validate( const Data& data );
+        };
 
-                std::size_t endLine( void ) const;
+        class DidSaveTextDocumentParams : public Data
+        {
+          public:
+            DidSaveTextDocumentParams( const Data& data );
 
-                u1 hasStartCharacter( void ) const;
+            DidSaveTextDocumentParams( const TextDocumentIdentifier& textDocument );
 
-                void setStartCharacter( const std::size_t startCharacter );
+            u1 hasText( void ) const;
 
-                std::size_t startCharacter( void ) const;
+            void setText( const std::string& text );
 
-                u1 hasEndCharacter( void ) const;
+            TextDocumentIdentifier textDocument( void ) const;
 
-                void setEndCharacter( const std::size_t endCharacter );
+            std::string text( void ) const;
 
-                std::size_t endCharacter( void ) const;
+            static void validate( const Data& data );
+        };
+        class DidCloseTextDocumentParams : public Data
+        {
+          public:
+            DidCloseTextDocumentParams( const TextDocumentIdentifier& textDocument );
 
-                u1 hasKind( void ) const;
+            DidCloseTextDocumentParams( const Data& data );
 
-                void setKind( const FoldingRangeKind kind );
+            TextDocumentIdentifier textDocument( void ) const;
 
-                std::string kind( void ) const;
+            static void validate( const Data& data );
+        };
 
-                static void validate( const Data& data );
-            };
-            using FoldingRanges = std::vector< FoldingRange >;
-            class FoldingRangeResult : public Data
-            {
-              public:
-                FoldingRangeResult( void );
+        class CompletionRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            CompletionRegistrationOptions( const Data& data );
 
-                FoldingRangeResult( const Data& data );
+            CompletionRegistrationOptions( const DocumentSelector& documentSelector );
 
-                FoldingRangeResult( const FoldingRanges ranges );
+            u1 hasTriggerCharacters( void ) const;
 
-                static void validate( const Data& data );
-            };
+            TriggerCharacters triggerCharacters( void ) const;
 
-            class ExecuteCommandParams : public Data
-            {
-              public:
-                ExecuteCommandParams( const Data& data );
+            void addTriggerCharacter( const std::string& triggerCharacter );
 
-                ExecuteCommandParams( const std::string& command );
+            u1 hasResolveProvider( void ) const;
 
-                std::string command( void ) const;
+            u1 resolveProvider( void ) const;
 
-                u1 hasArguments( void ) const;
+            void setResolveProvider( const u1 resolveProvider );
 
-                Data arguments( void ) const;
+            static void validate( const Data& data );
+        };
 
-                void addArgument( const Data& argument );
+        enum class CompletionTriggerKind
+        {
+            /**
+             * Completion was triggered by typing an identifier (24x7 code
+             * complete), manual invocation (e.g Ctrl+Space) or via API.
+             */
+            Invoked = 1,
 
-                static void validate( const Data& data );
-            };
+            /**
+             * Completion was triggered by a trigger character specified by
+             * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+             */
+            TriggerCharacter = 2,
 
-            using ExecuteCommandResult = Data;  // TODO: PPA: FIXME:
-        }
+            /**
+             * Completion was re-triggered as the current completion list is incomplete.
+             */
+            TriggerForIncompleteCompletions = 3
+        };
+
+        class CompletionContext : public Data
+        {
+          public:
+            CompletionContext( const Data& data );
+
+            CompletionContext( const CompletionTriggerKind triggerkind );
+
+            std::string triggerCharacter( void ) const;
+
+            void setTriggerCharacter( const std::string& triggerCharacter );
+
+            u1 hasTriggerCharacter( void ) const;
+
+            CompletionTriggerKind triggerKind( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class CompletionParams : public TextDocumentPositionParams
+        {
+          public:
+            CompletionParams( const Data& data );
+
+            CompletionParams(
+                const TextDocumentIdentifier& textDocument, const Position& position );
+
+            CompletionContext context( void ) const;
+
+            u1 hasContext( void ) const;
+
+            void setContext( const CompletionContext& context );
+
+            static void validate( const Data& data );
+        };
+
+        enum class MarkupKind
+        {
+            PLAINTEXT,
+            MARKDOWN
+        };
+
+        class MarkupContent : public Data
+        {
+          public:
+            MarkupContent( const Data& data );
+
+            MarkupContent( const std::string& value );  // kind will be plaintext
+
+            MarkupContent( const MarkupKind kind, const std::string& value );
+
+            std::string kind( void ) const;
+
+            std::string value( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        enum class InsertTextFormat
+        {
+            PlainText = 1,
+            Snippet = 2
+        };
+
+        enum class CompletionItemKind
+        {
+            Text = 1,
+            Method = 2,
+            Function = 3,
+            Constructor = 4,
+            Field = 5,
+            Variable = 6,
+            Class = 7,
+            Interface = 8,
+            Module = 9,
+            Property = 10,
+            Unit = 11,
+            Value = 12,
+            Enum = 13,
+            Keyword = 14,
+            Snippet = 15,
+            Color = 16,
+            File = 17,
+            Reference = 18,
+            Folder = 19,
+            EnumMember = 20,
+            Constant = 21,
+            Struct = 22,
+            Event = 23,
+            Operator = 24,
+            TypeParameter = 25
+        };
+
+        using CommitCharacters = std::vector< std::string >;
+
+        class CompletionItem : public Data
+        {
+          public:
+            CompletionItem( const Data& data );
+
+            CompletionItem( const std::string& label );
+
+            std::string label( void ) const;
+
+            u1 hasKind( void ) const;
+
+            void setKind( const CompletionItemKind kind );
+
+            CompletionItemKind kind( void ) const;
+
+            u1 hasDetail( void ) const;
+
+            void setDetail( const std::string& detail );
+
+            std::string detail( void ) const;
+
+            u1 hasDocumentation( void ) const;
+
+            void setDocumentation( const MarkupContent& doc );
+
+            MarkupContent documentation( void ) const;
+
+            u1 hasDeprecated( void ) const;
+
+            void setDeprecated( const u1 deprecated );
+
+            u1 isDeprecated( void ) const;
+
+            u1 hasPreselected( void ) const;
+
+            void setPreselected( const u1 preselected );
+
+            u1 isPreselected( void ) const;
+
+            u1 hasSortText( void ) const;
+
+            void setSortText( const std::string& sortText );
+
+            std::string sortText( void ) const;
+
+            u1 hasFilterText( void ) const;
+
+            void setFilterText( const std::string& filterText );
+
+            std::string filterText( void ) const;
+
+            u1 hasInsertText( void ) const;
+
+            void setInsertText( const std::string& insertText );
+
+            std::string insertText( void ) const;
+
+            u1 hasInsertTextFormat( void ) const;
+
+            void setInsertTextFormat( const InsertTextFormat insertTextFormat );
+
+            InsertTextFormat insertTextFormat( void ) const;
+
+            u1 hasTextEdit( void ) const;
+
+            void setTextEdit( const TextEdit& textEdit );
+
+            TextEdit textEdit( void ) const;
+
+            u1 hasAdditionalTextEdits( void ) const;
+
+            void addAdditionalTextEdit( const TextEdit& textEdit );
+
+            TextEdits additionalTextEdits( void ) const;
+
+            u1 hasCommitCharacters( void ) const;
+
+            void addCommitCharacter( const std::string& commitCharacter );
+
+            CommitCharacters commitCharacters( void ) const;
+
+            u1 hasCommand( void ) const;
+
+            void setCommand( const Command& command );
+
+            Command command( void ) const;
+
+            u1 hasData( void ) const;
+
+            void setData( const Data& data );
+
+            Data data( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using CompletionItems = std::vector< CompletionItem >;
+        class CompletionList : public Data
+        {
+          public:
+            CompletionList( const Data& data );
+
+            CompletionList( const u1 isIncomplete, const CompletionItems& items );
+
+            CompletionItems items( void ) const;
+
+            u1 isIncomplete( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using CompletionResolveResult = CompletionItem;
+
+        using SignatureHelpParams = TextDocumentPositionParams;
+
+        class CompletionResult : public Data
+        {
+          public:
+            CompletionResult( void );
+
+            CompletionResult( const Data& data );
+
+            CompletionResult( const CompletionList& list );
+
+            CompletionResult( const CompletionItems& items );
+
+            static void validate( const Data& data );
+        };
+
+        class ParameterInformation : public Data
+        {
+          public:
+            ParameterInformation( const Data& data );
+
+            ParameterInformation( const std::string& label );
+
+            std::string label( void ) const;
+
+            MarkupContent documentation( void ) const;
+
+            u1 hasDocumentation( void ) const;
+
+            void setDocumentation( const MarkupContent& doc );
+
+            static void validate( const Data& data );
+        };
+
+        using ParameterInformations = std::vector< ParameterInformation >;
+        class SignatureInformation : public Data
+        {
+          public:
+            SignatureInformation( const Data& data );
+
+            SignatureInformation( const std::string& label );
+
+            std::string label( void ) const;
+
+            MarkupContent documentation( void ) const;
+
+            u1 hasDocumentation( void ) const;
+
+            void setDocumentation( const MarkupContent& doc );
+
+            u1 hasParameters( void ) const;
+
+            ParameterInformations parameters( void ) const;
+
+            void setParameters( const ParameterInformations& parameters );
+
+            static void validate( const Data& data );
+        };
+
+        using SignatureInformations = std::vector< SignatureInformation >;
+        class SignatureHelp : public Data
+        {
+          public:
+            SignatureHelp( const Data& data );
+
+            SignatureHelp( const SignatureInformations& signatures );
+
+            SignatureInformations signatures( void ) const;
+
+            u1 hasActiveSignature( void ) const;
+
+            void setActiveSignature( const std::size_t activeSignature );
+
+            std::size_t activeSignature( void ) const;
+
+            u1 hasActiveParameter( void ) const;
+
+            void setActiveParameter( const std::size_t activeParameter );
+
+            std::size_t activeParameter( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class SignatureHelpResult : public Data
+        {
+          public:
+            SignatureHelpResult( void );
+
+            SignatureHelpResult( const Data& data );
+
+            SignatureHelpResult( const SignatureHelp& signature );
+
+            static void validate( const Data& data );
+        };
+
+        using TypeDefinitionParams = TextDocumentPositionParams;
+
+        using Locations = std::vector< Location >;
+
+        class LocationLink : public Data
+        {
+          public:
+            LocationLink( const Data& data );
+
+            LocationLink( const DocumentUri& targetUri, const Range& targetRange );
+
+            DocumentUri targetUri( void ) const;
+
+            Range targetRange( void ) const;
+
+            u1 hasOriginSelectionRange( void ) const;
+
+            void setOriginSelectionRange( const Range& range );
+
+            Range originSelectionRange( void ) const;
+
+            u1 hasTargetSelectionRange( void ) const;
+
+            void setTargetSelectionRange( const Range& range );
+
+            Range targetSelectionRange( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using LocationLinks = std::vector< LocationLink >;
+
+        class TypeDefinitionResult : public Data
+        {
+          public:
+            TypeDefinitionResult( const Data& data );
+
+            TypeDefinitionResult( const Locations& locations );
+
+            TypeDefinitionResult( const LocationLinks& locationLinks );
+
+            TypeDefinitionResult( const Location& location );
+
+            static void validate( const Data& data );
+        };
+
+        using TextDocumentImplementationResult = TypeDefinitionResult;
+
+        using TextDocumentImplementationParams = TextDocumentPositionParams;
+
+        class ReferenceContext : public Data
+        {
+          public:
+            ReferenceContext( const Data& data );
+
+            ReferenceContext( const u1 includeDeclaration );
+
+            u1 includeDeclaration( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class ReferenceParams : public TextDocumentPositionParams
+        {
+          public:
+            ReferenceParams( const Data& data );
+
+            ReferenceParams(
+                const TextDocumentIdentifier& textDocument,
+                const Position& position,
+                const ReferenceContext& context );
+
+            ReferenceContext context( void ) const;
+
+            static void validate( const Data& data );
+        };
+        class ReferenceResult : public Data
+        {
+          public:
+            ReferenceResult( const Data& data );
+
+            ReferenceResult( const Locations& locations );
+
+            static void validate( const Data& data );
+        };
+
+        enum class CodeActionKind
+        {
+            QuickFix,
+            Refactor,
+            RefactorExtract,
+            RefactorInline,
+            RefactorRewrite,
+            Source,
+            SourceOrganizeImports
+        };
+
+        class CodeActionOptions : public Data
+        {
+          public:
+            CodeActionOptions( const Data& data );
+
+            u1 hasCodeActionKinds( void ) const;
+
+            void addCodeActionKind( CodeActionKind kind );
+
+            std::vector< std::string > codeActionKinds( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using Diagnostics = std::vector< Diagnostic >;
+
+        class CodeActionContext : public Data
+        {
+          public:
+            CodeActionContext( const Data& data );
+
+            CodeActionContext( const Diagnostics& diagnostics );
+
+            Diagnostics diagnostics( void ) const;
+
+            u1 hasKind( void ) const;
+
+            void setKind( const CodeActionKind kind );
+
+            std::string kind( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class CodeActionParams : public Data
+        {
+          public:
+            CodeActionParams( const Data& data );
+
+            CodeActionParams(
+                const TextDocumentIdentifier& textDocument,
+                const Range& range,
+                const CodeActionContext& context );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            Range range( void ) const;
+
+            CodeActionContext context( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class CodeAction : public Data
+        {
+          public:
+            CodeAction( const Data& data );
+
+            CodeAction( const std::string& title );
+
+            std::string title( void ) const;
+
+            u1 hasKind( void ) const;
+
+            std::string kind( void ) const;
+
+            void setKind( const CodeActionKind kind );
+
+            u1 hasDiagnostics( void ) const;
+
+            Diagnostics diagnostics( void ) const;
+
+            void addDiagnostic( const Diagnostic& diagnostic );
+
+            u1 hasEdit( void ) const;
+
+            WorkspaceEdit edit( void ) const;
+
+            void setEdit( const WorkspaceEdit& edit );
+
+            void setCommand( const Command& command );
+
+            u1 hasCommand( void ) const;
+
+            Command command( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class CodeActionResult : public Data
+        {
+          public:
+            CodeActionResult( const Data& data );
+
+            CodeActionResult( const std::vector< Command >& commands );
+
+            CodeActionResult( void );
+
+            void addCommand( const Command& command );
+
+            static void validate( const Data& data );
+        };
+
+        class CodeActionRegistrationOptions
+        : public TextDocumentRegistrationOptions
+        , public CodeActionOptions
+        {
+        };
+
+        class PublishDiagnosticsParams : public Data
+        {
+          public:
+            PublishDiagnosticsParams( const Data& data );
+
+            PublishDiagnosticsParams(
+                const DocumentUri& uri, const std::vector< Diagnostic >& diagnostics );
+
+            DocumentUri uri( void ) const;
+
+            Data diagnostics( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using HoverParams = TextDocumentPositionParams;
+
+        class MarkedString : public Data
+        {
+          public:
+            MarkedString( const Data& data );
+
+            MarkedString( const std::string& language, const std::string& value );
+
+            std::string language( void ) const;
+
+            std::string value( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class HoverResult : public Data
+        {
+          public:
+            HoverResult( const Data& data );
+
+            HoverResult( const std::vector< MarkedString >& contents = {} );
+
+            Data contents( void ) const;
+
+            void addContent( const MarkedString& content );
+
+            u1 hasRange( void ) const;
+
+            Range range( void ) const;
+
+            void setRange( const Range& range );
+
+            static void validate( const Data& data );
+        };
+
+        using DefinitionParams = TextDocumentPositionParams;
+
+        class DefinitionResult : public Data
+        {
+          public:
+            DefinitionResult( const Data& data );
+
+            DefinitionResult( const Location& location );
+
+            DefinitionResult( const std::vector< Location > locations );
+
+            Data locations( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using DocumentHighlightParams = TextDocumentPositionParams;
+
+        enum class DocumentHighlightKind
+        {
+            Text = 1,
+            Read = 2,
+            Write = 3
+        };
+
+        class DocumentHighlight : public Data
+        {
+          public:
+            DocumentHighlight( const Data& data );
+
+            DocumentHighlight( const Range& range );
+
+            Range range( void ) const;
+
+            u1 hasKind( void ) const;
+
+            DocumentHighlightKind kind( void ) const;
+
+            void setKind( const DocumentHighlightKind kind );
+
+            static void validate( const Data& data );
+        };
+        using DocumentHighlights = std::vector< DocumentHighlight >;
+
+        class DocumentHighlightResult : public Data
+        {
+          public:
+            DocumentHighlightResult( void );
+
+            DocumentHighlightResult( const Data& data );
+
+            DocumentHighlightResult( const DocumentHighlights& highlights );
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentSymbolParams : public Data
+        {
+          public:
+            DocumentSymbolParams( const TextDocumentIdentifier& textDocument );
+
+            DocumentSymbolParams( const Data& data );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentSymbol;
+
+        using DocumentSymbols = std::vector< DocumentSymbol >;
+
+        class DocumentSymbol : public Data
+        {
+          public:
+            DocumentSymbol( const Data& data );
+
+            DocumentSymbol(
+                const std::string& name, const SymbolKind kind, Range range, Range selectionRange );
+
+            std::string name( void ) const;
+
+            SymbolKind kind( void ) const;
+
+            Range range( void ) const;
+
+            Range selectionRange( void ) const;
+
+            u1 hasDetail( void ) const;
+
+            void setDetail( const std::string& detail );
+
+            std::string detail( void ) const;
+
+            u1 hasDeprecated( void ) const;
+
+            u1 deprecated( void ) const;
+
+            void setDeprecated( const u1 deprecated );
+
+            u1 hasChildren( void ) const;
+
+            DocumentSymbols children( void ) const;
+
+            void addChild( const DocumentSymbol& symbol );
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentSymbolResult : public Data
+        {
+          public:
+            DocumentSymbolResult( void );
+
+            DocumentSymbolResult( const Data& data );
+
+            DocumentSymbolResult( const DocumentSymbols& symbols );
+
+            DocumentSymbolResult( const SymbolInformations& information );
+
+            static void validate( const Data& data );
+        };
+
+        class CodeLensParams : public Data
+        {
+          public:
+            CodeLensParams( const Data& data );
+
+            CodeLensParams( const TextDocumentIdentifier& textDocument );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class CodeLens : public Data
+        {
+          public:
+            CodeLens( const Data& data );
+
+            CodeLens( const Range& range );
+
+            Range range( void ) const;
+
+            u1 hasCommand( void ) const;
+
+            Command command( void ) const;
+
+            void setCommand( const Command& command );
+
+            u1 hasData( void ) const;
+
+            Data data( void ) const;
+
+            void setData( const Data& data );
+
+            static void validate( const Data& data );
+        };
+
+        class CodeLensResult : public Data
+        {
+          public:
+            CodeLensResult( const Data& data );
+
+            CodeLensResult( const std::vector< CodeLens >& codeLens = {} );
+
+            void addCodeLens( const CodeLens& codeLens );
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentLinkParams : public Data
+        {
+          public:
+            DocumentLinkParams( const Data& data );
+
+            DocumentLinkParams( const TextDocumentIdentifier& textDocument );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentLink : public Data
+        {
+          public:
+            DocumentLink( const Data& data );
+
+            DocumentLink( const Range& range );
+
+            Range range( void ) const;
+
+            u1 hasTarget( void ) const;
+
+            void setTarget( const DocumentUri& target );
+
+            DocumentUri target( void ) const;
+
+            u1 hasData( void ) const;
+
+            void setData( const Data& data );
+
+            Data data( void ) const;
+
+            static void validate( const Data& data );
+        };
+        using DocumentLinks = std::vector< DocumentLink >;
+        class DocumentLinkResult : public Data
+        {
+          public:
+            DocumentLinkResult( void );
+
+            DocumentLinkResult( const Data& data );
+
+            DocumentLinkResult( const DocumentLinks links );
+
+            static void validate( const Data& data );
+        };
+
+        using CodeLensResolveParams = CodeLens;
+        using CodeLensResolveResult = CodeLens;
+        using DocumentLinkResolveResult = DocumentLink;
+        using DocumentLinkResolveParams = DocumentLink;
+
+        class DocumentColorParams : public Data
+        {
+          public:
+            DocumentColorParams( const Data& data );
+
+            DocumentColorParams( const TextDocumentIdentifier& textDocument );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class Color : public Data
+        {
+          public:
+            Color( const Data& data );
+
+            Color( const float red, const float green, const float blue, const float alpha );
+
+            float red( void ) const;
+
+            float green( void ) const;
+
+            float blue( void ) const;
+
+            float alpha( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class ColorInformation : public Data
+        {
+          public:
+            ColorInformation( const Data& data );
+
+            ColorInformation( const Range& range, const Color& color );
+
+            Range range( void ) const;
+
+            Color color( void ) const;
+
+            static void validate( const Data& data );
+        };
+        using ColorInformations = std::vector< ColorInformation >;
+
+        class DocumentColorResult : public Data
+        {
+          public:
+            DocumentColorResult( const Data& data );
+
+            DocumentColorResult( const ColorInformations& colorInformations );
+
+            static void validate( const Data& data );
+        };
+
+        class ColorPresentationParams : public DocumentColorParams
+        {
+          public:
+            ColorPresentationParams( const Data& data );
+
+            ColorPresentationParams(
+                const TextDocumentIdentifier& textDocument,
+                const Color& color,
+                const Range& range );
+
+            Color color( void ) const;
+
+            Range range( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class ColorPresentation : public Data
+        {
+          public:
+            ColorPresentation( const Data& data );
+
+            ColorPresentation( const std::string& label );
+
+            std::string label( void ) const;
+
+            u1 hasTextEdit( void ) const;
+
+            void setTextEdit( const TextEdit& textEdit );
+
+            TextEdit textEdit( void ) const;
+
+            u1 hasAdditionalTextEdits( void ) const;
+
+            void addAdditionalTextEdit( const TextEdit& textEdit );
+
+            TextEdits additionalTextEdits( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using ColorPresentations = std::vector< ColorPresentation >;
+
+        class ColorPresentationResult : public Data
+        {
+          public:
+            ColorPresentationResult( const Data& data );
+
+            ColorPresentationResult( ColorPresentations presentations );
+
+            static void validate( const Data& data );
+        };
+
+        class FormattingOptions : public Data
+        {
+          private:
+            static void validateAdditionalOptions( const Data& data );
+
+          public:
+            FormattingOptions( const Data& data );
+
+            FormattingOptions( const std::size_t tabSize, const u1 insertSpaces );
+
+            std::size_t tabSize( void ) const;
+
+            void addBool( const std::string& key, const u1 boolean );
+
+            void addNumber( const std::string& key, const float number );
+
+            void addString( const std::string& key, const std::string& string );
+
+            u1 insertSpaces( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentFormattingParams : public Data
+        {
+          public:
+            DocumentFormattingParams( const Data& data );
+
+            DocumentFormattingParams(
+                const TextDocumentIdentifier& textDocument, const FormattingOptions& options );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            FormattingOptions options( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentFormattingResult : public Data
+        {
+          public:
+            DocumentFormattingResult( void );
+
+            DocumentFormattingResult( const Data& data );
+
+            DocumentFormattingResult( const TextEdits& edits );
+
+            static void validate( const Data& data );
+        };
+        class DocumentRangeFormattingParams : public DocumentFormattingParams
+        {
+          public:
+            DocumentRangeFormattingParams( const Data& data );
+
+            DocumentRangeFormattingParams(
+                const TextDocumentIdentifier& textDocument,
+                const Range& range,
+                const FormattingOptions& options );
+
+            Range range( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentOnTypeFormattingParams : public DocumentFormattingParams
+        {
+          public:
+            DocumentOnTypeFormattingParams( const Data& data );
+
+            DocumentOnTypeFormattingParams(
+                const TextDocumentIdentifier& textDocument,
+                const FormattingOptions& options,
+                const Position& position,
+                const std::string& ch );
+
+            Position position( void ) const;
+
+            std::string ch( void ) const;  // character that has been typed.
+
+            static void validate( const Data& data );
+        };
+
+        class DocumentOnTypeFormattingRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            DocumentOnTypeFormattingRegistrationOptions( const Data& data );
+
+            DocumentOnTypeFormattingRegistrationOptions(
+                const DocumentSelector& documentSelector,
+                const std::string& firstTriggerCharacter );
+
+            std::string firstTriggerCharacter( void ) const;
+
+            u1 hasMoreTriggerCharacter( void ) const;
+
+            void addMoreTriggerCharacter( const std::string& character );
+
+            std::vector< std::string > moreTriggerCharacter( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        using DocumentOnTypeFormattingResult = DocumentFormattingResult;
+
+        using DocumentRangeFormattingResult = DocumentFormattingResult;
+
+        class RenameParams : public Data
+        {
+          public:
+            RenameParams( const Data& data );
+
+            RenameParams(
+                const TextDocumentIdentifier& textDocument,
+                const Position& position,
+                const std::string& newName );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            Position position( void ) const;
+
+            std::string newName( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class RenameRegistrationOptions : public TextDocumentRegistrationOptions
+        {
+          public:
+            RenameRegistrationOptions( const Data& data );
+
+            RenameRegistrationOptions( const DocumentSelector& selector );
+
+            u1 hasPrepareProvider( void ) const;
+
+            void setPrepareProvider( const u1 prepareProvider );
+
+            u1 prepareProvider( void ) const;
+
+            static void validate( const Data& data );
+        };
+
+        class RenameResult : public Data
+        {
+          public:
+            RenameResult( void );
+
+            RenameResult( const Data& data );
+
+            RenameResult( const WorkspaceEdit& edit );
+
+            static void validate( const Data& data );
+        };
+
+        using PrepareRenameParams = TextDocumentPositionParams;
+
+        class PrepareRenameResult : public Data
+        {
+          public:
+            PrepareRenameResult( void );
+
+            PrepareRenameResult( const Data& data );
+
+            PrepareRenameResult( const Range& range, const std::string& placeholder );
+
+            static void validate( const Data& data );
+        };
+
+        class FoldingRangeParams : public Data
+        {
+          public:
+            FoldingRangeParams( const Data& data );
+
+            FoldingRangeParams( const TextDocumentIdentifier& textDocument );
+
+            TextDocumentIdentifier textDocument( void ) const;
+
+            static void validate( const Data& data );
+        };
+        enum class FoldingRangeKind
+        {
+            Comment,
+            Imports,
+            Region
+        };
+
+        class FoldingRange : public Data
+        {
+          public:
+            FoldingRange( const Data& data );
+
+            FoldingRange( const std::size_t startLine, const std::size_t endLine );
+
+            std::size_t startLine( void ) const;
+
+            std::size_t endLine( void ) const;
+
+            u1 hasStartCharacter( void ) const;
+
+            void setStartCharacter( const std::size_t startCharacter );
+
+            std::size_t startCharacter( void ) const;
+
+            u1 hasEndCharacter( void ) const;
+
+            void setEndCharacter( const std::size_t endCharacter );
+
+            std::size_t endCharacter( void ) const;
+
+            u1 hasKind( void ) const;
+
+            void setKind( const FoldingRangeKind kind );
+
+            std::string kind( void ) const;
+
+            static void validate( const Data& data );
+        };
+        using FoldingRanges = std::vector< FoldingRange >;
+        class FoldingRangeResult : public Data
+        {
+          public:
+            FoldingRangeResult( void );
+
+            FoldingRangeResult( const Data& data );
+
+            FoldingRangeResult( const FoldingRanges ranges );
+
+            static void validate( const Data& data );
+        };
+
+        class ExecuteCommandParams : public Data
+        {
+          public:
+            ExecuteCommandParams( const Data& data );
+
+            ExecuteCommandParams( const std::string& command );
+
+            std::string command( void ) const;
+
+            u1 hasArguments( void ) const;
+
+            Data arguments( void ) const;
+
+            void addArgument( const Data& argument );
+
+            static void validate( const Data& data );
+        };
+
+        using ExecuteCommandResult = Data;  // TODO: PPA: FIXME:
     }
+}
 }
 
 #endif  // _LIBSTDHL_CPP_NETWORK_LSP_CONTENT_H_

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2203,9 +2203,21 @@ namespace libstdhl
 
             using CompletionResolveResult = CompletionItem;
 
-            using CompletionResult = CompletionList;
-
             using SignatureHelpParams = TextDocumentPositionParams;
+
+            class CompletionResult : public Data
+            {
+              public:
+                CompletionResult( void );
+
+                CompletionResult( const Data& data );
+
+                CompletionResult( const CompletionList& list );
+
+                CompletionResult( const CompletionItems& items );
+
+                static void validate( const Data& data );
+            };
 
             class ParameterInformation : public Data
             {

--- a/src/cpp/net/lsp/Content.h
+++ b/src/cpp/net/lsp/Content.h
@@ -2765,7 +2765,7 @@ namespace libstdhl
 
                 static void validate( const Data& data );
             };
-
+            using DocumentLinks = std::vector< DocumentLink >;
             class DocumentLinkResult : public Data
             {
               public:
@@ -2773,7 +2773,7 @@ namespace libstdhl
 
                 DocumentLinkResult( const Data& data );
 
-                DocumentLinkResult( const DocumentLink link );
+                DocumentLinkResult( const DocumentLinks links );
 
                 static void validate( const Data& data );
             };

--- a/src/cpp/net/lsp/Exception.h
+++ b/src/cpp/net/lsp/Exception.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -115,6 +115,8 @@ namespace libstdhl
 
                 constexpr const char* codeLens = "codeLens";
 
+                constexpr const char* codeLens_resolve = "codeLens/resolve";
+
                 constexpr const char* codeLensProvider = "codeLensProvider";
 
                 constexpr const char* color = "color";
@@ -132,6 +134,8 @@ namespace libstdhl
                 constexpr const char* completion = "completion";
 
                 constexpr const char* completionItem = "completionItem";
+
+                constexpr const char* completionItem_resolve = "completionItem/resolve";
 
                 constexpr const char* completionProvider = "completionProvider";
 
@@ -182,6 +186,8 @@ namespace libstdhl
                 constexpr const char* documentLink = "documentLink";
 
                 constexpr const char* documentLinkProvider = "documentLinkProvider";
+
+                constexpr const char* documentLink_resolve = "documentLink/resolve";
 
                 constexpr const char* documentOnTypeFormattingProvider =
                     "documentOnTypeFormattingProvider";
@@ -470,14 +476,60 @@ namespace libstdhl
 
                 constexpr const char* textDocument_codeLens = "textDocument/codeLens";
 
+                constexpr const char* textDocument_colorPresentation =
+                    "textDocument/colorPresentation";
+
+                constexpr const char* textDocument_completion = "textDocument/completion";
+
+                constexpr const char* textDocument_definition = "textDocument/definition";
+
                 constexpr const char* textDocument_didChange = "textDocument/didChange";
+
+                constexpr const char* textDocument_didClose = "textDocument/didClose";
 
                 constexpr const char* textDocument_didOpen = "textDocument/didOpen";
 
+                constexpr const char* textDocument_didSave = "textDocument/didSave";
+
+                constexpr const char* textDocument_documentColor = "textDocument/documentColor";
+
+                constexpr const char* textDocument_documentHighlight =
+                    "textDocument/documentHighlight";
+
+                constexpr const char* textDocument_documentLink = "textDocument/documentLink";
+
+                constexpr const char* textDocument_documentSymbol = "textDocument/documentSymbol";
+
+                constexpr const char* textDocument_foldingRange = "textDocument/foldingRange";
+
+                constexpr const char* textDocument_formatting = "textDocument/formatting";
+
                 constexpr const char* textDocument_hover = "textDocument/hover";
+
+                constexpr const char* textDocument_implementation = "textDocument/implementation";
+
+                constexpr const char* textDocument_onTypeFormatting =
+                    "textDocument/onTypeFormatting";
+
+                constexpr const char* textDocument_prepareRename = "textDocument/prepareRename";
 
                 constexpr const char* textDocument_publishDiagnostics =
                     "textDocument/publishDiagnostics";
+
+                constexpr const char* textDocument_rangeFormatting = "textDocument/rangeFormatting";
+
+                constexpr const char* textDocument_references = "textDocument/references";
+
+                constexpr const char* textDocument_rename = "textDocument/rename";
+
+                constexpr const char* textDocument_signatureHelp = "textDocument/signatureHelp";
+
+                constexpr const char* textDocument_typeDefinition = "textDocument/typeDefinition";
+
+                constexpr const char* textDocument_willSave = "textDocument/willSave";
+
+                constexpr const char* textDocument_willSaveWaitUntil =
+                    "textDocument/willSaveWaitUntil";
 
                 constexpr const char* textEdit = "textEdit";
 
@@ -527,6 +579,19 @@ namespace libstdhl
 
                 constexpr const char* workspace_configuration = "workspace/configuration";
 
+                constexpr const char* workspace_didChangeWorkspaceFolders =
+                    "workspace/didChangeWorkspaceFolders";
+
+                constexpr const char* workspace_didChangeConfiguration =
+                    "workspace/didChangeConfiguration";
+
+                constexpr const char* workspace_didChangeWatchedFiles =
+                    "workspace/didChangeWatchedFiles";
+
+                constexpr const char* workspace_executeCommand = "workspace/executeCommand";
+
+                constexpr const char* workspace_symbol = "workspace/symbol";
+
                 constexpr const char* workspace_workspaceFolders = "workspace/workspaceFolders";
 
                 constexpr const char* workspaceEdit = "workspaceEdit";
@@ -534,8 +599,6 @@ namespace libstdhl
                 constexpr const char* workspaceFolders = "workspaceFolders";
 
                 constexpr const char* workspaceSymbolProvider = "workspaceSymbolProvider";
-
-                constexpr const char* workspace_executeCommand = "workspace/executeCommand";
 
                 // X
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -304,6 +304,8 @@ namespace libstdhl
 
                 constexpr const char* options = "options";
 
+                constexpr const char* originSelectionRange = "originSelectionRange";
+
                 // P
 
                 constexpr const char* parameters = "parameters";
@@ -420,9 +422,15 @@ namespace libstdhl
 
                 // T
 
+                constexpr const char* tabSize = "tabSize";
+
                 constexpr const char* target = "target";
 
-                constexpr const char* tabSize = "tabSize";
+                constexpr const char* targetRange = "targetRange";
+
+                constexpr const char* targetSelectionRange = "targetSelectionRange";
+
+                constexpr const char* targetUri = "targetUri";
 
                 constexpr const char* telemetry_event = "telemetry/event";
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -117,6 +117,8 @@ namespace libstdhl
 
                 constexpr const char* color = "color";
 
+                constexpr const char* colorProvider = "colorProvider";
+
                 constexpr const char* command = "command";
 
                 constexpr const char* commands = "commands";
@@ -220,6 +222,8 @@ namespace libstdhl
                 constexpr const char* firstTriggerCharacter = "firstTriggerCharacter";
 
                 constexpr const char* filterText = "filterText";
+
+                constexpr const char* foldingRangeProvider = "foldingRangeProvider";
 
                 constexpr const char* formatting = "formatting";
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -159,7 +159,7 @@ namespace libstdhl
 
                 constexpr const char* definitionProvider = "definitionProvider";
 
-                constexpr const char* DELETE = "delete";
+                constexpr const char* deletion = "delete";
 
                 constexpr const char* deprecated = "deprecated";
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -93,6 +93,8 @@ namespace libstdhl
 
                 constexpr const char* change = "change";
 
+                constexpr const char* changeNotifications = "changeNotifications";
+
                 constexpr const char* changes = "changes";
 
                 constexpr const char* character = "character";
@@ -433,6 +435,8 @@ namespace libstdhl
                 constexpr const char* startLine = "startLine";
 
                 constexpr const char* startCharacter = "startCharacter";
+
+                constexpr const char* supported = "supported";
 
                 constexpr const char* symbol = "symbol";
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -139,6 +139,8 @@ namespace libstdhl
 
                 constexpr const char* context = "context";
 
+                constexpr const char* create = "create";
+
                 // D
 
                 constexpr const char* data = "data";

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -243,6 +243,8 @@ namespace libstdhl
 
                 constexpr const char* imports = "imports";
 
+                constexpr const char* implementationProvider = "implementationProvider";
+
                 constexpr const char* includeDeclaration = "includeDeclaration";
 
                 constexpr const char* includeText = "includeText";
@@ -480,6 +482,8 @@ namespace libstdhl
                 constexpr const char* triggerKind = "triggerKind";
 
                 constexpr const char* type = "type";
+
+                constexpr const char* typeDefinitionProvider = "typeDefinitionProvider";
 
                 // U
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -352,6 +352,8 @@ namespace libstdhl
 
                 constexpr const char* reason = "reason";
 
+                constexpr const char* recursive = "recursive";
+
                 constexpr const char* red = "red";
 
                 constexpr const char* refactor = "refactor";

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -85,6 +85,8 @@ namespace libstdhl
 
                 // C
 
+                constexpr const char* cancelRequest = "$/cancelRequest";
+
                 constexpr const char* capabilities = "capabilities";
 
                 constexpr const char* ch = "ch";

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -149,6 +149,8 @@ namespace libstdhl
 
                 constexpr const char* definitionProvider = "definitionProvider";
 
+                constexpr const char* DELETE = "delete";
+
                 constexpr const char* deprecated = "deprecated";
 
                 constexpr const char* detail = "detail";

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -300,7 +300,11 @@ namespace libstdhl
 
                 constexpr const char* newText = "newText";
 
+                constexpr const char* newUri = "newUri";
+
                 // O
+
+                constexpr const char* oldUri = "oldUri";
 
                 constexpr const char* onTypeFormatting = "onTypeFormatting";
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -235,6 +235,8 @@ namespace libstdhl
 
                 constexpr const char* id = "id";
 
+                constexpr const char* ignoreIfExists = "ignoreIfExists";
+
                 constexpr const char* imports = "imports";
 
                 constexpr const char* includeDeclaration = "includeDeclaration";
@@ -305,6 +307,8 @@ namespace libstdhl
                 constexpr const char* options = "options";
 
                 constexpr const char* originSelectionRange = "originSelectionRange";
+
+                constexpr const char* overwrite = "overwrite";
 
                 // P
 

--- a/src/cpp/net/lsp/Identifier.h
+++ b/src/cpp/net/lsp/Identifier.h
@@ -135,6 +135,8 @@ namespace libstdhl
 
                 constexpr const char* completionProvider = "completionProvider";
 
+                constexpr const char* configuration = "configuration";
+
                 constexpr const char* containerName = "containerName";
 
                 constexpr const char* contentChanges = "contentChanges";

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -209,13 +209,17 @@ void ServerInterface::client_unregisterCapability(
     request( msg, responseCallback );
 }
 
-WorkspaceFoldersResult ServerInterface::workspace_workspaceFolders( void )
+void ServerInterface::workspace_workspaceFolders(
+    const std::function< void( WorkspaceFoldersResult ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::workspace_workspaceFolders } );
-    // request( msg );   // TODO: FIXME: @Clasc
-    // TODO: FIXME: @Clasc: handle response
-    auto folders = std::vector< WorkspaceFolder >();
-    return WorkspaceFoldersResult( folders );
+    RequestMessage msg( request_id++, std::string{ Identifier::workspace_workspaceFolders } );
+    msg.setParams( Data() );
+    const auto responseCallback = [&]( const ResponseMessage& response ) {
+        auto result = static_cast< const WorkspaceFoldersResult >( response.result() );
+        callback( result );
+        // TODO: @ppaulweber: error handling has to be defined
+    };
+    request( msg, responseCallback );
 }
 
 Data ServerInterface::workspace_configuration( const ConfigurationParams& params )

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -192,15 +192,12 @@ void ServerInterface::client_registerCapability(
 }
 
 void ServerInterface::client_unregisterCapability(
-    const UnregistrationParams& params, const std::function< void( void ) >& callback )
+    const UnregistrationParams& params,
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( incrementID(), std::string{ Identifier::client_unregisterCapability } );
     msg.setParams( params );
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        callback();
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::workspace_workspaceFolders(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -103,6 +103,12 @@ void ServerInterface::flush( const std::function< void( const Message& ) >& call
 
     m_notificationBuffer[ pos ].clear();
 }
+void ServerInterface::server_cancel( const CancelParams& params ) noexcept
+{
+    NotificationMessage msg( std::string{ Identifier::cancelRequest } );
+    msg.setParams( params );
+    notify( msg );
+}
 
 void ServerInterface::window_showMessage( const ShowMessageParams& params ) noexcept
 {

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -236,13 +236,18 @@ void ServerInterface::workspace_configuration(
     request( msg, responseCallback );
 }
 
-ApplyWorkspaceEditResult ServerInterface::workspace_applyEdit(
-    const ApplyWorkspaceEditParams& params )
+void ServerInterface::workspace_applyEdit(
+    const ApplyWorkspaceEditParams& params,
+    const std::function< void( const ApplyWorkspaceEditResult& ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::workspace_applyEdit } );
-    // request( msg );   // TODO: FIXME: @Clasc
-    // TODO: FIXME: @Clasc: handle response
-    return ApplyWorkspaceEditResult( true );
+    RequestMessage msg( request_id++, std::string{ Identifier::workspace_applyEdit } );
+    msg.setParams( params );
+    const auto responseCallback = [&]( const ResponseMessage& response ) {
+        auto result = static_cast< const ApplyWorkspaceEditResult& >( response.result() );
+        callback( result );
+        // TODO: @ppaulweber: error handling has to be defined
+    };
+    request( msg, responseCallback );
 }
 
 void ServerInterface::textDocument_publishDiagnostics(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -65,7 +65,7 @@ ServerInterface::ServerInterface( void )
 
 //
 //
-// ServerInterface (base)
+// ServerInterface Lifetime
 //
 
 void ServerInterface::server_cancel( const CancelParams& params ) noexcept
@@ -77,7 +77,7 @@ void ServerInterface::server_cancel( const CancelParams& params ) noexcept
 
 //
 //
-// ServerInterface (window)
+// ServerInterface Window
 //
 
 void ServerInterface::window_showMessage( const ShowMessageParams& params ) noexcept
@@ -105,7 +105,7 @@ void ServerInterface::window_logMessage( const LogMessageParams& params ) noexce
 
 //
 //
-// ServerInterface (telemetry)
+// ServerInterface Telemetry
 //
 
 void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noexcept
@@ -117,7 +117,7 @@ void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noex
 
 //
 //
-// ServerInterface (client)
+// ServerInterface Client
 //
 
 void ServerInterface::client_registerCapability(
@@ -140,7 +140,7 @@ void ServerInterface::client_unregisterCapability(
 
 //
 //
-// ServerInterface (workspace)
+// ServerInterface Workspace
 //
 
 void ServerInterface::workspace_workspaceFolders(
@@ -171,7 +171,17 @@ void ServerInterface::workspace_applyEdit(
 
 //
 //
-// ServerInterface (textDocument)
+// ServerInterface Workspace
+//
+
+//
+//
+// ServerInterface Text Synchronization
+//
+
+//
+//
+// ServerInterface Diagnostics
 //
 
 void ServerInterface::textDocument_publishDiagnostics(
@@ -181,6 +191,11 @@ void ServerInterface::textDocument_publishDiagnostics(
     msg.setParams( params );
     notify( msg );
 }
+
+//
+//
+// ServerInterface Language Features
+//
 
 //
 //

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -183,16 +183,12 @@ void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noex
 }
 
 void ServerInterface::client_registerCapability(
-    const RegistrationParams& params, const std::function< void( void ) >& callback )
+    const RegistrationParams& params,
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( incrementID(), std::string{ Identifier::client_registerCapability } );
     msg.setParams( params );
-
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        callback();
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::client_unregisterCapability(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -63,6 +63,11 @@ ServerInterface::ServerInterface( void )
 {
 }
 
+std::size_t ServerInterface::incrementID( void )
+{
+    return request_id++;
+}
+
 void ServerInterface::respond( const ResponseMessage& message )
 {
     std::lock_guard< std::mutex > guard( m_responseBufferLock );
@@ -158,7 +163,7 @@ void ServerInterface::window_showMessageRequest(
     const ShowMessageRequestParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::window_showMessageRequest } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::window_showMessageRequest } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -180,7 +185,7 @@ void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noex
 void ServerInterface::client_registerCapability(
     const RegistrationParams& params, const std::function< void( void ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::client_registerCapability } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::client_registerCapability } );
     msg.setParams( params );
 
     const auto responseCallback = [&]( const ResponseMessage& response ) {
@@ -193,7 +198,7 @@ void ServerInterface::client_registerCapability(
 void ServerInterface::client_unregisterCapability(
     const UnregistrationParams& params, const std::function< void( void ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::client_unregisterCapability } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::client_unregisterCapability } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
         callback();
@@ -205,7 +210,7 @@ void ServerInterface::client_unregisterCapability(
 void ServerInterface::workspace_workspaceFolders(
     const std::function< void( const WorkspaceFoldersResult& ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::workspace_workspaceFolders } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_workspaceFolders } );
     msg.setParams( Data() );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
         auto result = static_cast< const WorkspaceFoldersResult >( response.result() );
@@ -219,7 +224,7 @@ void ServerInterface::workspace_configuration(
     const ConfigurationParams& params,
     const std::function< void( const ConfigurationResult& ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::workspace_configuration } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_configuration } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
         auto result = static_cast< const ConfigurationResult >( response.result() );
@@ -233,7 +238,7 @@ void ServerInterface::workspace_applyEdit(
     const ApplyWorkspaceEditParams& params,
     const std::function< void( const ApplyWorkspaceEditResult& ) >& callback )
 {
-    RequestMessage msg( request_id++, std::string{ Identifier::workspace_applyEdit } );
+    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_applyEdit } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
         auto result = static_cast< const ApplyWorkspaceEditResult >( response.result() );

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -197,12 +197,16 @@ void ServerInterface::client_registerCapability(
     request( msg, responseCallback );
 }
 
-void ServerInterface::client_unregisterCapability( const UnregistrationParams& params )
+void ServerInterface::client_unregisterCapability(
+    const UnregistrationParams& params, const std::function< void( void ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::client_unregisterCapability } );
+    RequestMessage msg( request_id++, std::string{ Identifier::client_unregisterCapability } );
     msg.setParams( params );
-    // request( msg );   // TODO: FIXME: @Clasc
-    // TODO: FIXME: @Clasc: handle response
+    const auto responseCallback = [&]( const ResponseMessage& response ) {
+        callback();
+        // TODO: @ppaulweber: error handling has to be defined
+    };
+    request( msg, responseCallback );
 }
 
 WorkspaceFoldersResult ServerInterface::workspace_workspaceFolders( void )

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -44,6 +44,8 @@
 
 #include "Identifier.h"
 
+#include <libstdhl/data/log/Timestamp>
+
 using namespace libstdhl;
 using namespace Network;
 using namespace LSP;
@@ -91,7 +93,7 @@ void ServerInterface::window_showMessageRequest(
     const ShowMessageRequestParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::window_showMessageRequest } );
+    RequestMessage msg( nextId(), std::string{ Identifier::window_showMessageRequest } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -124,7 +126,7 @@ void ServerInterface::client_registerCapability(
     const RegistrationParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::client_registerCapability } );
+    RequestMessage msg( nextId(), std::string{ Identifier::client_registerCapability } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -133,7 +135,7 @@ void ServerInterface::client_unregisterCapability(
     const UnregistrationParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::client_unregisterCapability } );
+    RequestMessage msg( nextId(), std::string{ Identifier::client_unregisterCapability } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -146,7 +148,7 @@ void ServerInterface::client_unregisterCapability(
 void ServerInterface::workspace_workspaceFolders(
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_workspaceFolders } );
+    RequestMessage msg( nextId(), std::string{ Identifier::workspace_workspaceFolders } );
     msg.setParams( Data() );
     request( msg, callback );
 }
@@ -155,7 +157,7 @@ void ServerInterface::workspace_configuration(
     const ConfigurationParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_configuration } );
+    RequestMessage msg( nextId(), std::string{ Identifier::workspace_configuration } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -164,7 +166,7 @@ void ServerInterface::workspace_applyEdit(
     const ApplyWorkspaceEditParams& params,
     const std::function< void( const ResponseMessage& ) >& callback )
 {
-    RequestMessage msg( incrementID(), std::string{ Identifier::workspace_applyEdit } );
+    RequestMessage msg( nextId(), std::string{ Identifier::workspace_applyEdit } );
     msg.setParams( params );
     request( msg, callback );
 }
@@ -261,6 +263,7 @@ void ServerInterface::handle( const ResponseMessage& message )
     {
         const std::function< void( const ResponseMessage& ) >& callback = result->second;
         callback( message );
+        m_requestCallback.erase( result );
     }
 }
 
@@ -280,9 +283,10 @@ void ServerInterface::notify( const NotificationMessage& message )
     m_notificationBuffer[ m_notificationBufferSlot ].emplace_back( message );
 }
 
-std::size_t ServerInterface::incrementID( void )
+std::string ServerInterface::nextId( void )
 {
-    return request_id++;
+    auto timestamp = Log::Timestamp();
+    return timestamp.utc();
 }
 
 //

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -219,16 +219,11 @@ void ServerInterface::workspace_configuration(
 
 void ServerInterface::workspace_applyEdit(
     const ApplyWorkspaceEditParams& params,
-    const std::function< void( const ApplyWorkspaceEditResult& ) >& callback )
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( incrementID(), std::string{ Identifier::workspace_applyEdit } );
     msg.setParams( params );
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ApplyWorkspaceEditResult >( response.result() );
-        callback( result );
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::textDocument_publishDiagnostics(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -272,8 +272,6 @@ void ServerInterface::request(
 {
     std::lock_guard< std::mutex > guard( m_requestBufferLock );
     m_requestBuffer[ m_requestBufferSlot ].emplace_back( message );
-
-    // TODO: @ppaulweber: check for unique value (msg id) condition @Clasc
     m_requestCallback[ message.id() ] = callback;
 }
 

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -210,16 +210,11 @@ void ServerInterface::workspace_workspaceFolders(
 
 void ServerInterface::workspace_configuration(
     const ConfigurationParams& params,
-    const std::function< void( const ConfigurationResult& ) >& callback )
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( incrementID(), std::string{ Identifier::workspace_configuration } );
     msg.setParams( params );
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ConfigurationResult >( response.result() );
-        callback( result );
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::workspace_applyEdit(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -222,12 +222,18 @@ void ServerInterface::workspace_workspaceFolders(
     request( msg, responseCallback );
 }
 
-Data ServerInterface::workspace_configuration( const ConfigurationParams& params )
+void ServerInterface::workspace_configuration(
+    const ConfigurationParams& params,
+    const std::function< void( ConfigurationResult ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::workspace_configuration } );
-    // request( msg );   // TODO: FIXME: @Clasc
-    // TODO: FIXME: @Clasc: handle response
-    return Data( Data::object() );
+    RequestMessage msg( request_id++, std::string{ Identifier::workspace_configuration } );
+    msg.setParams( params );
+    const auto responseCallback = [&]( const ResponseMessage& response ) {
+        auto result = static_cast< const ConfigurationResult >( response.result() );
+        callback( result );
+        // TODO: @ppaulweber: error handling has to be defined
+    };
+    request( msg, responseCallback );
 }
 
 ApplyWorkspaceEditResult ServerInterface::workspace_applyEdit(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -201,16 +201,11 @@ void ServerInterface::client_unregisterCapability(
 }
 
 void ServerInterface::workspace_workspaceFolders(
-    const std::function< void( const WorkspaceFoldersResult& ) >& callback )
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( incrementID(), std::string{ Identifier::workspace_workspaceFolders } );
     msg.setParams( Data() );
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const WorkspaceFoldersResult >( response.result() );
-        callback( result );
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::workspace_configuration(

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -158,7 +158,7 @@ void ServerInterface::window_showMessageRequest(
     const ShowMessageRequestParams& params,
     const std::function< void( const ShowMessageRequestResult& ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::window_showMessageRequest } );
+    RequestMessage msg( request_id++, std::string{ Identifier::window_showMessageRequest } );
     msg.setParams( params );
 
     const auto responseCallback = [&]( const ResponseMessage& response ) {
@@ -187,7 +187,7 @@ void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noex
 void ServerInterface::client_registerCapability(
     const RegistrationParams& params, const std::function< void( void ) >& callback )
 {
-    RequestMessage msg( 0 /* TODO */, std::string{ Identifier::client_registerCapability } );
+    RequestMessage msg( request_id++, std::string{ Identifier::client_registerCapability } );
     msg.setParams( params );
 
     const auto responseCallback = [&]( const ResponseMessage& response ) {

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -184,12 +184,17 @@ void ServerInterface::telemetry_event( const TelemetryEventParams& params ) noex
     notify( msg );
 }
 
-void ServerInterface::client_registerCapability( const RegistrationParams& params )
+void ServerInterface::client_registerCapability(
+    const RegistrationParams& params, const std::function< void( void ) >& callback )
 {
     RequestMessage msg( 0 /* TODO */, std::string{ Identifier::client_registerCapability } );
     msg.setParams( params );
-    // request( msg );   // TODO: FIXME: @Clasc
-    // TODO: FIXME: @Clasc: handle response
+
+    const auto responseCallback = [&]( const ResponseMessage& response ) {
+        callback();
+        // TODO: @ppaulweber: error handling has to be defined
+    };
+    request( msg, responseCallback );
 }
 
 void ServerInterface::client_unregisterCapability( const UnregistrationParams& params )

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -82,7 +82,7 @@ void ServerInterface::request(
     m_requestBuffer[ m_requestBufferSlot ].emplace_back( message );
 
     // TODO: @ppaulweber: check for unique value (msg id) condition @Clasc
-    m_requestCallback[ message.id() ] = &callback;
+    m_requestCallback[ message.id() ] = callback;
 }
 
 void ServerInterface::handle( const ResponseMessage& message )
@@ -90,7 +90,8 @@ void ServerInterface::handle( const ResponseMessage& message )
     const auto result = m_requestCallback.find( message.id() );
     if( result != m_requestCallback.end() )
     {
-        ( *result->second )( message );
+        const std::function< void( const ResponseMessage& ) >& callback = result->second;
+        callback( message );
     }
 }
 

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -156,18 +156,11 @@ void ServerInterface::window_showMessage( const ShowMessageParams& params ) noex
 
 void ServerInterface::window_showMessageRequest(
     const ShowMessageRequestParams& params,
-    const std::function< void( const ShowMessageRequestResult& ) >& callback )
+    const std::function< void( const ResponseMessage& ) >& callback )
 {
     RequestMessage msg( request_id++, std::string{ Identifier::window_showMessageRequest } );
     msg.setParams( params );
-
-    const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ShowMessageRequestResult >( response.result() );
-        callback( result );
-        // TODO: @ppaulweber: error handling has to be defined
-    };
-
-    request( msg, responseCallback );
+    request( msg, callback );
 }
 
 void ServerInterface::window_logMessage( const LogMessageParams& params ) noexcept

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -162,7 +162,7 @@ void ServerInterface::window_showMessageRequest(
     msg.setParams( params );
 
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ShowMessageRequestResult& >( response.result() );
+        auto result = static_cast< const ShowMessageRequestResult >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };
@@ -215,7 +215,7 @@ void ServerInterface::workspace_workspaceFolders(
     RequestMessage msg( request_id++, std::string{ Identifier::workspace_workspaceFolders } );
     msg.setParams( Data() );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const WorkspaceFoldersResult& >( response.result() );
+        auto result = static_cast< const WorkspaceFoldersResult >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };
@@ -229,7 +229,7 @@ void ServerInterface::workspace_configuration(
     RequestMessage msg( request_id++, std::string{ Identifier::workspace_configuration } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ConfigurationResult& >( response.result() );
+        auto result = static_cast< const ConfigurationResult >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };
@@ -243,7 +243,7 @@ void ServerInterface::workspace_applyEdit(
     RequestMessage msg( request_id++, std::string{ Identifier::workspace_applyEdit } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ApplyWorkspaceEditResult& >( response.result() );
+        auto result = static_cast< const ApplyWorkspaceEditResult >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };

--- a/src/cpp/net/lsp/Interface.cpp
+++ b/src/cpp/net/lsp/Interface.cpp
@@ -162,7 +162,7 @@ void ServerInterface::window_showMessageRequest(
     msg.setParams( params );
 
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ShowMessageRequestResult >( response.result() );
+        auto result = static_cast< const ShowMessageRequestResult& >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };
@@ -210,12 +210,12 @@ void ServerInterface::client_unregisterCapability(
 }
 
 void ServerInterface::workspace_workspaceFolders(
-    const std::function< void( WorkspaceFoldersResult ) >& callback )
+    const std::function< void( const WorkspaceFoldersResult& ) >& callback )
 {
     RequestMessage msg( request_id++, std::string{ Identifier::workspace_workspaceFolders } );
     msg.setParams( Data() );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const WorkspaceFoldersResult >( response.result() );
+        auto result = static_cast< const WorkspaceFoldersResult& >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };
@@ -224,12 +224,12 @@ void ServerInterface::workspace_workspaceFolders(
 
 void ServerInterface::workspace_configuration(
     const ConfigurationParams& params,
-    const std::function< void( ConfigurationResult ) >& callback )
+    const std::function< void( const ConfigurationResult& ) >& callback )
 {
     RequestMessage msg( request_id++, std::string{ Identifier::workspace_configuration } );
     msg.setParams( params );
     const auto responseCallback = [&]( const ResponseMessage& response ) {
-        auto result = static_cast< const ConfigurationResult >( response.result() );
+        auto result = static_cast< const ConfigurationResult& >( response.result() );
         callback( result );
         // TODO: @ppaulweber: error handling has to be defined
     };

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -182,8 +182,9 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_configuration
                 // server to client request
-                virtual ConfigurationResult workspace_configuration(
-                    const ConfigurationParams& params ) final;
+                virtual void workspace_configuration(
+                    const ConfigurationParams& params,
+                    const std::function< void( ConfigurationResult ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWatchedFiles
                 // client to server notification

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -72,23 +72,6 @@ namespace libstdhl
 
                 virtual ~ServerInterface( void ) = default;
 
-                std::size_t incrementID( void );
-                /**
-                   user interface for message interactions
-                */
-
-                void respond( const ResponseMessage& message );
-
-                void notify( const NotificationMessage& message );
-
-                void request(
-                    const RequestMessage& message,
-                    const std::function< void( const ResponseMessage& ) >& callback );
-
-                void handle( const ResponseMessage& message );
-
-                void flush( const std::function< void( const Message& ) >& callback );
-
                 //
                 //
                 //  Base Protocol
@@ -365,6 +348,21 @@ namespace libstdhl
                 // client to server request
                 virtual FoldingRangeResult textDocument_foldingRange(
                     const FoldingRangeParams& params ) = 0;
+
+                void flush( const std::function< void( const Message& ) >& callback );
+
+                void respond( const ResponseMessage& message );
+
+                void handle( const ResponseMessage& message );
+
+              private:
+                void request(
+                    const RequestMessage& message,
+                    const std::function< void( const ResponseMessage& ) >& callback );
+
+                void notify( const NotificationMessage& message );
+
+                std::size_t incrementID( void );
 
               private:
                 std::size_t request_id = 0;

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -74,7 +74,7 @@ namespace libstdhl
 
                 //
                 //
-                //  Base Protocol
+                //  Lifetime
                 //
 
                 // https://microsoft.github.io/language-server-protocol/specification#initialize
@@ -193,7 +193,7 @@ namespace libstdhl
 
                 //
                 //
-                //  Text Document
+                //  Text Synchronization
                 //
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_didOpen
@@ -227,6 +227,11 @@ namespace libstdhl
                 virtual void textDocument_didClose(
                     const DidCloseTextDocumentParams& params ) noexcept = 0;
 
+                //
+                //
+                // Diagnostics
+                //
+
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics
                 // server to client notification
                 virtual void textDocument_publishDiagnostics(
@@ -255,6 +260,11 @@ namespace libstdhl
                 // client to server request
                 virtual SignatureHelpResult textDocument_signatureHelp(
                     const SignatureHelpParams& params ) = 0;
+
+                // https://microsoft.github.io/language-server-protocol/specification#textDocument_declaration
+                // client to server request
+                // TODO: FIXME: @ppaulweber: API introduced in version 3.14.0, as goes for
+                // LocationLink, next PR
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_definition
                 // client to server request

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -168,7 +168,7 @@ namespace libstdhl
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders
                 // server to client request
                 virtual void workspace_workspaceFolders(
-                    const std::function< void( WorkspaceFoldersResult ) >& callback ) final;
+                    const std::function< void( const WorkspaceFoldersResult& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
                 // client to server notification
@@ -184,7 +184,7 @@ namespace libstdhl
                 // server to client request
                 virtual void workspace_configuration(
                     const ConfigurationParams& params,
-                    const std::function< void( ConfigurationResult ) >& callback ) final;
+                    const std::function< void( const ConfigurationResult& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWatchedFiles
                 // client to server notification

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -379,6 +379,7 @@ namespace libstdhl
                     const FoldingRangeParams& params ) = 0;
 
               private:
+                std::size_t request_id = 0;
                 std::vector< Message > m_responseBuffer[ 2 ];
                 std::size_t m_responseBufferSlot;
                 std::mutex m_responseBufferLock;

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -127,8 +127,7 @@ namespace libstdhl
                 // server to client request
                 virtual void window_showMessageRequest(
                     const ShowMessageRequestParams& params,
-                    const std::function< void( const ShowMessageRequestResult& ) >& callback )
-                    final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#window_logMessage
                 // server to client notification

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -158,7 +158,7 @@ namespace libstdhl
                 // server to client request
                 virtual void client_unregisterCapability(
                     const UnregistrationParams& params,
-                    const std::function< void( void ) >& callback ) final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 //
                 //

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -150,7 +150,9 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#client_registerCapability
                 // server to client request
-                virtual void client_registerCapability( const RegistrationParams& params ) final;
+                virtual void client_registerCapability(
+                    const RegistrationParams& params,
+                    const std::function< void( void ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#client_unregisterCapability
                 // server to client request

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -167,7 +167,8 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders
                 // server to client request
-                virtual WorkspaceFoldersResult workspace_workspaceFolders( void ) final;
+                virtual void workspace_workspaceFolders(
+                    const std::function< void( WorkspaceFoldersResult ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
                 // client to server notification

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -168,7 +168,7 @@ namespace libstdhl
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders
                 // server to client request
                 virtual void workspace_workspaceFolders(
-                    const std::function< void( const WorkspaceFoldersResult& ) >& callback ) final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders
                 // client to server notification

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -152,7 +152,7 @@ namespace libstdhl
                 // server to client request
                 virtual void client_registerCapability(
                     const RegistrationParams& params,
-                    const std::function< void( void ) >& callback ) final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#client_unregisterCapability
                 // server to client request

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -115,6 +115,7 @@ namespace libstdhl
                 virtual void server_cancel( const CancelParams& params ) noexcept final;
                 // client to server notification
                 virtual void client_cancel( const CancelParams& params ) noexcept = 0;
+
                 //
                 //
                 //  Window
@@ -255,56 +256,50 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual CompletionResult textDocument_completion(
                     const CompletionParams& params ) = 0;
+
                 // https://microsoft.github.io/language-server-protocol/specification#completionItem_resolve
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual CompletionResolveResult completionItem_resolve(
                     const CompletionParams& params ) = 0;
+
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
                 // client to server request
                 virtual HoverResult textDocument_hover( const HoverParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_signatureHelp
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual SignatureHelpResult textDocument_signatureHelp(
                     const SignatureHelpParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_definition
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DefinitionResult textDocument_definition(
                     const DefinitionParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_typeDefinition
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual TypeDefinitionResult textDocument_typeDefinition(
                     const TypeDefinitionParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual TextDocumentImplementationResult textDocument_implementation(
                     const TextDocumentImplementationParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_references
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual ReferenceResult textDocument_references(
                     const ReferenceParams& params ) = 0;
+
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentHighlightResult textDocument_documentHighlight(
                     const DocumentHighlightParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentSymbolResult textDocument_documentSymbol(
                     const DocumentSymbolParams& params ) = 0;
 
@@ -319,65 +314,55 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#codeLens_resolve
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual CodeLensResolveResult codeLens_resolve(
                     const CodeLensResolveParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_documentLink
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentLinkResult textDocument_documentLink(
                     const DocumentLinkParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#documentLink_resolve
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentLinkResolveResult documentLink_resolve(
                     const DocumentLinkResolveParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentColorResult textDocument_documentColor(
                     const DocumentColorParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_colorPresentation
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual ColorPresentationResult textDocument_colorPresentation(
                     const ColorPresentationParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_formatting
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentFormattingResult textDocument_formatting(
                     const DocumentFormattingParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_rangeFormatting
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentRangeFormattingResult textDocument_rangeFormatting(
                     const DocumentRangeFormattingParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_onTypeFormatting
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual DocumentOnTypeFormattingResult textDocument_onTypeFormatting(
                     const DocumentOnTypeFormattingParams& params ) = 0;
+
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_rename
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual RenameResult textDocument_rename( const RenameParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareRename
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual PrepareRenameResult textDocument_prepareRename(
                     const PrepareRenameParams& params ) = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_foldingRange
                 // client to server request
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
                 virtual FoldingRangeResult textDocument_foldingRange(
                     const FoldingRangeParams& params ) = 0;
 

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -193,7 +193,6 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_symbol
                 // client to server request
-                // TODO: FIXME: @ppaulweber: replace 'void' with 'SymbolInformation|null' @Clasc
                 virtual WorkspaceSymbolResult workspace_symbol(
                     const WorkspaceSymbolParams& params ) = 0;
 
@@ -204,8 +203,10 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_applyEdit
                 // server to client request
-                virtual ApplyWorkspaceEditResult workspace_applyEdit(
-                    const ApplyWorkspaceEditParams& params ) final;
+                virtual void workspace_applyEdit(
+                    const ApplyWorkspaceEditParams& params,
+                    const std::function< void( const ApplyWorkspaceEditResult& ) >& callback )
+                    final;
 
                 //
                 //

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -372,10 +372,9 @@ namespace libstdhl
 
                 void notify( const NotificationMessage& message );
 
-                std::size_t incrementID( void );
+                std::string nextId( void );
 
               private:
-                std::size_t request_id = 0;
                 std::vector< Message > m_responseBuffer[ 2 ];
                 std::size_t m_responseBufferSlot;
                 std::mutex m_responseBufferLock;

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -205,8 +205,7 @@ namespace libstdhl
                 // server to client request
                 virtual void workspace_applyEdit(
                     const ApplyWorkspaceEditParams& params,
-                    const std::function< void( const ApplyWorkspaceEditResult& ) >& callback )
-                    final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 //
                 //

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -103,10 +103,10 @@ namespace libstdhl
                 virtual void exit( void ) noexcept = 0;
 
                 // https://microsoft.github.io/language-server-protocol/specification#cancelRequest
-                // client to server notification
                 // server to client notification
-                // TODO: FIXME: @ppaulweber: provide interface @Clasc
-
+                virtual void server_cancel( const CancelParams& params ) noexcept final;
+                // client to server notification
+                virtual void client_cancel( const CancelParams& params ) noexcept = 0;
                 //
                 //
                 //  Window

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -72,6 +72,7 @@ namespace libstdhl
 
                 virtual ~ServerInterface( void ) = default;
 
+                std::size_t incrementID( void );
                 /**
                    user interface for message interactions
                 */

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -47,6 +47,7 @@
 #include <libstdhl/net/lsp/Message>
 
 #include <mutex>
+#include <unordered_map>
 
 /**
    @brief    TBD
@@ -78,6 +79,12 @@ namespace libstdhl
                 void respond( const ResponseMessage& message );
 
                 void notify( const NotificationMessage& message );
+
+                void request(
+                    const RequestMessage& message,
+                    const std::function< void( const ResponseMessage& ) >& callback );
+
+                void handle( const ResponseMessage& message );
 
                 void flush( const std::function< void( const Message& ) >& callback );
 
@@ -118,8 +125,10 @@ namespace libstdhl
 
                 // https://microsoft.github.io/language-server-protocol/specification#window_showMessageRequest
                 // server to client request
-                virtual ShowMessageRequestResult window_showMessageRequest(
-                    const ShowMessageRequestParams& params ) final;
+                virtual void window_showMessageRequest(
+                    const ShowMessageRequestParams& params,
+                    const std::function< void( const ShowMessageRequestResult& ) >& callback )
+                    final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#window_logMessage
                 // server to client notification
@@ -375,6 +384,14 @@ namespace libstdhl
                 std::vector< Message > m_notificationBuffer[ 2 ];
                 std::size_t m_notificationBufferSlot;
                 std::mutex m_notificationBufferLock;
+
+                std::vector< Message > m_requestBuffer[ 2 ];
+                std::size_t m_requestBufferSlot;
+                std::mutex m_requestBufferLock;
+                std::unordered_map<
+                    std::string,
+                    const std::function< void( const ResponseMessage& ) >* >
+                    m_requestCallback;
 
                 std::mutex m_serverFlushLock;
             };

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -388,9 +388,7 @@ namespace libstdhl
                 std::vector< Message > m_requestBuffer[ 2 ];
                 std::size_t m_requestBufferSlot;
                 std::mutex m_requestBufferLock;
-                std::unordered_map<
-                    std::string,
-                    const std::function< void( const ResponseMessage& ) >* >
+                std::unordered_map< std::string, std::function< void( const ResponseMessage& ) > >
                     m_requestCallback;
 
                 std::mutex m_serverFlushLock;

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -157,7 +157,8 @@ namespace libstdhl
                 // https://microsoft.github.io/language-server-protocol/specification#client_unregisterCapability
                 // server to client request
                 virtual void client_unregisterCapability(
-                    const UnregistrationParams& params ) final;
+                    const UnregistrationParams& params,
+                    const std::function< void( void ) >& callback ) final;
 
                 //
                 //

--- a/src/cpp/net/lsp/Interface.h
+++ b/src/cpp/net/lsp/Interface.h
@@ -184,7 +184,7 @@ namespace libstdhl
                 // server to client request
                 virtual void workspace_configuration(
                     const ConfigurationParams& params,
-                    const std::function< void( const ConfigurationResult& ) >& callback ) final;
+                    const std::function< void( const ResponseMessage& ) >& callback ) final;
 
                 // https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWatchedFiles
                 // client to server notification

--- a/src/cpp/net/lsp/LSP.h
+++ b/src/cpp/net/lsp/LSP.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/LSP.h
+++ b/src/cpp/net/lsp/LSP.h
@@ -46,10 +46,12 @@
 
 #include <libstdhl/net/lsp/Content>
 #include <libstdhl/net/lsp/Exception>
+#include <libstdhl/net/lsp/Identifier>
 #include <libstdhl/net/lsp/Interface>
 #include <libstdhl/net/lsp/Message>
 #include <libstdhl/net/lsp/Packet>
 #include <libstdhl/net/lsp/Protocol>
+#include <libstdhl/net/lsp/Server>
 
 /**
    @brief    TBD

--- a/src/cpp/net/lsp/Message.cpp
+++ b/src/cpp/net/lsp/Message.cpp
@@ -118,8 +118,8 @@ void Message::process( ServerInterface& interface ) const
 void Message::validate( const Data& data )
 {
     static const auto context = "LSP: Message:";
-    Content::validateTypeIsObject( context, data );
-    Content::validatePropertyIsString( context, data, Identifier::jsonrpc, true );
+    Json::validateTypeIsObject( context, data );
+    Json::validatePropertyIsString( context, data, Identifier::jsonrpc, true );
 }
 
 Message Message::parse( const std::string& data )
@@ -337,9 +337,9 @@ void RequestMessage::validate( const Data& data )
 {
     static const auto context = "LSP: RequestMessage:";
     Message::validate( data );
-    Content::validatePropertyIsUuid( context, data, Identifier::jsonrpc, true );
-    Content::validatePropertyIsString( context, data, Identifier::method, true );
-    Content::validatePropertyIsObject( context, data, Identifier::params, false );
+    Json::validatePropertyIsUuid( context, data, Identifier::jsonrpc, true );
+    Json::validatePropertyIsString( context, data, Identifier::method, true );
+    Json::validatePropertyIsObject( context, data, Identifier::params, false );
 }
 
 //
@@ -440,8 +440,8 @@ void NotificationMessage::validate( const Data& data )
 {
     static const auto context = "LSP: NotificationMessage:";
     Message::validate( data );
-    Content::validatePropertyIsString( context, data, Identifier::method, true );
-    Content::validatePropertyIsObject( context, data, Identifier::params, false );
+    Json::validatePropertyIsString( context, data, Identifier::method, true );
+    Json::validatePropertyIsObject( context, data, Identifier::params, false );
 }
 
 //
@@ -528,9 +528,9 @@ void ResponseMessage::validate( const Data& data )
 {
     static const auto context = "LSP: ResponseMessage:";
     Message::validate( data );
-    Content::validatePropertyIsUuid( context, data, Identifier::id, true );
-    Content::validatePropertyIsObject( context, data, Identifier::result, false );
-    Content::validatePropertyIsObject( context, data, Identifier::error, false );
+    Json::validatePropertyIsUuid( context, data, Identifier::id, true );
+    Json::validatePropertyIsObject( context, data, Identifier::result, false );
+    Json::validatePropertyIsObject( context, data, Identifier::error, false );
 }
 
 //

--- a/src/cpp/net/lsp/Message.cpp
+++ b/src/cpp/net/lsp/Message.cpp
@@ -281,7 +281,14 @@ void RequestMessage::process( ServerInterface& interface ) const
                 response.setResult( nullptr );
                 break;
             }
-            // workspace
+                // workspace
+            case String::value( Identifier::workspace_symbol ):
+            {
+                const auto& parameters = WorkspaceSymbolParams( params() );
+                auto result = interface.workspace_symbol( parameters );
+                response.setResult( result );
+                break;
+            }
             case String::value( Identifier::workspace_executeCommand ):
             {
                 const auto& parameters = ExecuteCommandParams( params() );
@@ -289,11 +296,83 @@ void RequestMessage::process( ServerInterface& interface ) const
                 response.setResult( result );
                 break;
             }
-            // document
+                // document
+            case String::value( Identifier::textDocument_willSaveWaitUntil ):
+            {
+                const auto& parameters = WillSaveTextDocumentParams( params() );
+                const auto& result = interface.textDocument_willSaveWaitUntil( parameters );
+                response.setResult( result );
+                break;
+            }
+
+            // language features
+            case String::value( Identifier::textDocument_completion ):
+            {
+                const auto& parameters = CompletionParams( params() );
+                const auto& result = interface.textDocument_completion( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::completionItem_resolve ):
+            {
+                const auto& parameters = CompletionParams( params() );
+                const auto& result = interface.completionItem_resolve( parameters );
+                response.setResult( result );
+                break;
+            }
             case String::value( Identifier::textDocument_hover ):
             {
                 const auto& parameters = HoverParams( params() );
                 const auto& result = interface.textDocument_hover( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_signatureHelp ):
+            {
+                const auto& parameters = SignatureHelpParams( params() );
+                const auto& result = interface.textDocument_signatureHelp( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_definition ):
+            {
+                const auto& parameters = DefinitionParams( params() );
+                const auto& result = interface.textDocument_definition( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_typeDefinition ):
+            {
+                const auto& parameters = TypeDefinitionParams( params() );
+                const auto& result = interface.textDocument_typeDefinition( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_implementation ):
+            {
+                const auto& parameters = TextDocumentImplementationParams( params() );
+                const auto& result = interface.textDocument_implementation( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_references ):
+            {
+                const auto& parameters = ReferenceParams( params() );
+                const auto& result = interface.textDocument_references( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_documentHighlight ):
+            {
+                const auto& parameters = DocumentHighlightParams( params() );
+                const auto& result = interface.textDocument_documentHighlight( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_documentSymbol ):
+            {
+                const auto& parameters = DocumentSymbolParams( params() );
+                const auto& result = interface.textDocument_documentSymbol( parameters );
                 response.setResult( result );
                 break;
             }
@@ -308,6 +387,83 @@ void RequestMessage::process( ServerInterface& interface ) const
             {
                 const auto& parameters = CodeLensParams( params() );
                 const auto& result = interface.textDocument_codeLens( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::codeLens_resolve ):
+            {
+                const auto& parameters = CodeLensResolveParams( params() );
+                const auto& result = interface.codeLens_resolve( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_documentLink ):
+            {
+                const auto& parameters = DocumentLinkParams( params() );
+                const auto& result = interface.textDocument_documentLink( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::documentLink_resolve ):
+            {
+                const auto& parameters = DocumentLinkResolveParams( params() );
+                const auto& result = interface.documentLink_resolve( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_documentColor ):
+            {
+                const auto& parameters = DocumentColorParams( params() );
+                const auto& result = interface.textDocument_documentColor( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_colorPresentation ):
+            {
+                const auto& parameters = ColorPresentationParams( params() );
+                const auto& result = interface.textDocument_colorPresentation( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_formatting ):
+            {
+                const auto& parameters = DocumentFormattingParams( params() );
+                const auto& result = interface.textDocument_formatting( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_rangeFormatting ):
+            {
+                const auto& parameters = DocumentRangeFormattingParams( params() );
+                const auto& result = interface.textDocument_rangeFormatting( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_onTypeFormatting ):
+            {
+                const auto& parameters = DocumentOnTypeFormattingParams( params() );
+                const auto& result = interface.textDocument_onTypeFormatting( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_rename ):
+            {
+                const auto& parameters = RenameParams( params() );
+                const auto& result = interface.textDocument_rename( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_prepareRename ):
+            {
+                const auto& parameters = PrepareRenameParams( params() );
+                const auto& result = interface.textDocument_prepareRename( parameters );
+                response.setResult( result );
+                break;
+            }
+            case String::value( Identifier::textDocument_foldingRange ):
+            {
+                const auto& parameters = FoldingRangeParams( params() );
+                const auto& result = interface.textDocument_foldingRange( parameters );
                 response.setResult( result );
                 break;
             }
@@ -396,9 +552,34 @@ void NotificationMessage::process( ServerInterface& interface ) const
                 interface.initialized();
                 break;
             }
+            case String::value( Identifier::cancelRequest ):
+            {
+                const auto& parameters = CancelParams( params() );
+                interface.client_cancel( parameters );
+                break;
+            }
             case String::value( Identifier::exit ):
             {
                 interface.exit();
+                break;
+            }
+            // workspace
+            case String::value( Identifier::workspace_didChangeWorkspaceFolders ):
+            {
+                const auto& parameters = DidChangeWorkspaceFoldersParams( params() );
+                interface.workspace_didChangeWorkspaceFolders( parameters );
+                break;
+            }
+            case String::value( Identifier::workspace_didChangeConfiguration ):
+            {
+                const auto& parameters = DidChangeConfigurationParams( params() );
+                interface.workspace_didChangeConfiguration( parameters );
+                break;
+            }
+            case String::value( Identifier::workspace_didChangeWatchedFiles ):
+            {
+                const auto& parameters = DidChangeWatchedFilesParams( params() );
+                interface.workspace_didChangeWatchedFiles( parameters );
                 break;
             }
             // document
@@ -412,6 +593,24 @@ void NotificationMessage::process( ServerInterface& interface ) const
             {
                 const auto& parameters = DidChangeTextDocumentParams( params() );
                 interface.textDocument_didChange( parameters );
+                break;
+            }
+            case String::value( Identifier::textDocument_willSave ):
+            {
+                const auto& parameters = WillSaveTextDocumentParams( params() );
+                interface.textDocument_willSave( parameters );
+                break;
+            }
+            case String::value( Identifier::textDocument_didSave ):
+            {
+                const auto& parameters = DidSaveTextDocumentParams( params() );
+                interface.textDocument_didSave( parameters );
+                break;
+            }
+            case String::value( Identifier::textDocument_didClose ):
+            {
+                const auto& parameters = DidCloseTextDocumentParams( params() );
+                interface.textDocument_didClose( parameters );
                 break;
             }
             default:

--- a/src/cpp/net/lsp/Message.cpp
+++ b/src/cpp/net/lsp/Message.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Message.cpp
+++ b/src/cpp/net/lsp/Message.cpp
@@ -190,10 +190,11 @@ Message Message::parse( const std::string& data )
         case ID::UNKNOWN:  // [[fallthrough]]
         case ID::_SIZE_:
         {
-            throw std::invalid_argument( "LSP: unknown JSON-RPC message payload" );
-            return Message();
+            break;
         }
     }
+    throw std::invalid_argument( "LSP: unknown JSON-RPC message payload" );
+    return Message();
 }
 
 //
@@ -456,10 +457,10 @@ ResponseMessage::ResponseMessage( const Data& data )
 ResponseMessage::ResponseMessage( const std::size_t id )
 : Message( ID::RESPONSE_MESSAGE )
 {
-    operator[]( Identifier::id ) = id;
+    operator[]( Identifier::id ) = std::to_string( id );
 }
 
-ResponseMessage::ResponseMessage( const std::string id )
+ResponseMessage::ResponseMessage( const std::string& id )
 : Message( ID::RESPONSE_MESSAGE )
 {
     operator[]( Identifier::id ) = id;
@@ -469,6 +470,11 @@ ResponseMessage::ResponseMessage( void )
 : Message( ID::RESPONSE_MESSAGE )
 {
     operator[]( Identifier::id ) = nullptr;
+}
+
+std::string ResponseMessage::id( void ) const
+{
+    return at( Identifier::id ).get< std::string >();
 }
 
 u1 ResponseMessage::hasResult( void ) const
@@ -515,7 +521,7 @@ void ResponseMessage::setError( const ErrorCode code, const std::string& name, c
 
 void ResponseMessage::process( ServerInterface& interface ) const
 {
-    assert( !" TODO! " );
+    interface.handle( *this );
 }
 
 void ResponseMessage::validate( const Data& data )

--- a/src/cpp/net/lsp/Message.h
+++ b/src/cpp/net/lsp/Message.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Message.h
+++ b/src/cpp/net/lsp/Message.h
@@ -195,9 +195,11 @@ namespace libstdhl
 
                 ResponseMessage( const std::size_t id );
 
-                ResponseMessage( const std::string id );
+                ResponseMessage( const std::string& id );
 
                 ResponseMessage( void );
+
+                std::string id( void ) const;
 
                 u1 hasResult( void ) const;
 

--- a/src/cpp/net/lsp/Packet.cpp
+++ b/src/cpp/net/lsp/Packet.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Packet.h
+++ b/src/cpp/net/lsp/Packet.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Protocol.cpp
+++ b/src/cpp/net/lsp/Protocol.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Protocol.h
+++ b/src/cpp/net/lsp/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Server.cpp
+++ b/src/cpp/net/lsp/Server.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Server.cpp
+++ b/src/cpp/net/lsp/Server.cpp
@@ -1,0 +1,252 @@
+//
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libstdhl>
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libstdhl is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libstdhl
+//  statically or dynamically with other modules is making a combined work
+//  based on libstdhl. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libstdhl give you permission to link libstdhl
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libstdhl. If you modify libstdhl, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#include "Server.h"
+
+#include "Identifier.h"
+
+using namespace libstdhl;
+using namespace Network;
+using namespace LSP;
+
+Server::Server( void )
+{
+}
+
+//
+//
+//  Workspace
+//
+
+void Server::workspace_didChangeWorkspaceFolders(
+    const DidChangeWorkspaceFoldersParams& params ) noexcept
+{
+}
+
+void Server::workspace_didChangeConfiguration( const DidChangeConfigurationParams& params ) noexcept
+{
+}
+
+void Server::workspace_didChangeWatchedFiles( const DidChangeWatchedFilesParams& params ) noexcept
+{
+}
+
+WorkspaceSymbolResult Server::workspace_symbol( const WorkspaceSymbolParams& params )
+{
+    return WorkspaceSymbolResult( SymbolInformations() );
+}
+
+ExecuteCommandResult Server::workspace_executeCommand( const ExecuteCommandParams& params )
+{
+    return ExecuteCommandResult();
+}
+
+//
+//
+//  Text Synchronization
+//
+
+void Server::textDocument_didOpen( const DidOpenTextDocumentParams& params ) noexcept
+{
+}
+
+void Server::textDocument_didChange( const DidChangeTextDocumentParams& params ) noexcept
+{
+}
+
+void Server::textDocument_willSave( const WillSaveTextDocumentParams& params ) noexcept
+{
+}
+
+WillSaveWaitUntilResponse Server::textDocument_willSaveWaitUntil(
+    const WillSaveTextDocumentParams& params )
+{
+    return WillSaveWaitUntilResponse( TextEdits() );
+}
+
+void Server::textDocument_didSave( const DidSaveTextDocumentParams& params ) noexcept
+{
+}
+
+void Server::textDocument_didClose( const DidCloseTextDocumentParams& params ) noexcept
+{
+}
+
+//
+//
+//  Language Features
+//
+
+CompletionResult Server::textDocument_completion( const CompletionParams& params )
+{
+    return CompletionResult();
+}
+
+CompletionResolveResult Server::completionItem_resolve( const CompletionParams& params )
+{
+    return CompletionResolveResult( Data() );
+}
+
+HoverResult Server::textDocument_hover( const HoverParams& params )
+{
+    return HoverResult();
+}
+
+SignatureHelpResult Server::textDocument_signatureHelp( const SignatureHelpParams& params )
+{
+    return SignatureHelpResult();
+}
+
+// https://microsoft.github.io/language-server-protocol/specification#textDocument_declaration
+// client to server request
+// TODO: FIXME: @ppaulweber: API introduced in version 3.14.0, as goes for
+// LocationLink, next PR
+
+DefinitionResult Server::textDocument_definition( const DefinitionParams& params )
+{
+    return DefinitionResult( Data() );
+}
+
+TypeDefinitionResult Server::textDocument_typeDefinition( const TypeDefinitionParams& params )
+{
+    return TypeDefinitionResult( Data() );
+}
+
+TextDocumentImplementationResult Server::textDocument_implementation(
+    const TextDocumentImplementationParams& params )
+{
+    return TextDocumentImplementationResult( Data() );
+}
+
+ReferenceResult Server::textDocument_references( const ReferenceParams& params )
+{
+    return ReferenceResult( Data() );
+}
+
+DocumentHighlightResult Server::textDocument_documentHighlight(
+    const DocumentHighlightParams& params )
+{
+    return DocumentHighlightResult();
+}
+
+DocumentSymbolResult Server::textDocument_documentSymbol( const DocumentSymbolParams& params )
+{
+    return DocumentSymbolResult();
+}
+
+CodeActionResult Server::textDocument_codeAction( const CodeActionParams& params )
+{
+    return CodeActionResult();
+}
+
+CodeLensResult Server::textDocument_codeLens( const CodeLensParams& params )
+{
+    return CodeLensResult();
+}
+
+CodeLensResolveResult Server::codeLens_resolve( const CodeLensResolveParams& params )
+{
+    return CodeLensResolveResult( Data() );
+}
+
+DocumentLinkResult Server::textDocument_documentLink( const DocumentLinkParams& params )
+{
+    return DocumentLinkResult();
+}
+
+DocumentLinkResolveResult Server::documentLink_resolve( const DocumentLinkResolveParams& params )
+{
+    return DocumentLinkResolveResult( Data() );
+}
+
+DocumentColorResult Server::textDocument_documentColor( const DocumentColorParams& params )
+{
+    return DocumentColorResult( ColorInformations() );
+}
+
+ColorPresentationResult Server::textDocument_colorPresentation(
+    const ColorPresentationParams& params )
+{
+    return ColorPresentationResult( ColorPresentations() );
+}
+
+DocumentFormattingResult Server::textDocument_formatting( const DocumentFormattingParams& params )
+{
+    return DocumentFormattingResult();
+}
+
+DocumentRangeFormattingResult Server::textDocument_rangeFormatting(
+    const DocumentRangeFormattingParams& params )
+{
+    return DocumentRangeFormattingResult();
+}
+
+DocumentOnTypeFormattingResult Server::textDocument_onTypeFormatting(
+    const DocumentOnTypeFormattingParams& params )
+{
+    return DocumentOnTypeFormattingResult();
+}
+
+RenameResult Server::textDocument_rename( const RenameParams& params )
+{
+    return RenameResult();
+}
+
+PrepareRenameResult Server::textDocument_prepareRename( const PrepareRenameParams& params )
+{
+    return PrepareRenameResult();
+}
+
+FoldingRangeResult Server::textDocument_foldingRange( const FoldingRangeParams& params )
+{
+    return FoldingRangeResult();
+}
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/cpp/net/lsp/Server.h
+++ b/src/cpp/net/lsp/Server.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/lsp/Server.h
+++ b/src/cpp/net/lsp/Server.h
@@ -1,0 +1,197 @@
+//
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libstdhl>
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libstdhl is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libstdhl
+//  statically or dynamically with other modules is making a combined work
+//  based on libstdhl. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libstdhl give you permission to link libstdhl
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libstdhl. If you modify libstdhl, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#pragma once
+#ifndef _LIBSTDHL_CPP_NETWORK_LSP_SERVER_H_
+#define _LIBSTDHL_CPP_NETWORK_LSP_SERVER_H_
+
+#include <libstdhl/net/lsp/Interface>
+
+/**
+   @brief    TBD
+
+   TBD
+*/
+
+namespace libstdhl
+{
+    namespace Network
+    {
+        namespace LSP
+        {
+            class Server : public ServerInterface
+            {
+              public:
+                Server( void );
+
+                virtual ~Server( void ) = default;
+
+                //
+                //
+                //  Workspace
+                //
+
+                virtual void workspace_didChangeWorkspaceFolders(
+                    const DidChangeWorkspaceFoldersParams& params ) noexcept;
+
+                virtual void workspace_didChangeConfiguration(
+                    const DidChangeConfigurationParams& params ) noexcept;
+
+                virtual void workspace_didChangeWatchedFiles(
+                    const DidChangeWatchedFilesParams& params ) noexcept;
+
+                virtual WorkspaceSymbolResult workspace_symbol(
+                    const WorkspaceSymbolParams& params );
+
+                virtual ExecuteCommandResult workspace_executeCommand(
+                    const ExecuteCommandParams& params );
+
+                //
+                //
+                //  Text Synchronization
+                //
+
+                virtual void textDocument_didOpen(
+                    const DidOpenTextDocumentParams& params ) noexcept;
+
+                virtual void textDocument_didChange(
+                    const DidChangeTextDocumentParams& params ) noexcept;
+
+                virtual void textDocument_willSave(
+                    const WillSaveTextDocumentParams& params ) noexcept;
+
+                virtual WillSaveWaitUntilResponse textDocument_willSaveWaitUntil(
+                    const WillSaveTextDocumentParams& params );
+
+                virtual void textDocument_didSave(
+                    const DidSaveTextDocumentParams& params ) noexcept;
+
+                virtual void textDocument_didClose(
+                    const DidCloseTextDocumentParams& params ) noexcept;
+
+                //
+                //
+                //  Language Features
+                //
+
+                virtual CompletionResult textDocument_completion( const CompletionParams& params );
+
+                virtual CompletionResolveResult completionItem_resolve(
+                    const CompletionParams& params );
+
+                virtual HoverResult textDocument_hover( const HoverParams& params );
+
+                virtual SignatureHelpResult textDocument_signatureHelp(
+                    const SignatureHelpParams& params );
+
+                // https://microsoft.github.io/language-server-protocol/specification#textDocument_declaration
+                // client to server request
+                // TODO: FIXME: @ppaulweber: API introduced in version 3.14.0, as goes for
+                // LocationLink, next PR
+
+                virtual DefinitionResult textDocument_definition( const DefinitionParams& params );
+
+                virtual TypeDefinitionResult textDocument_typeDefinition(
+                    const TypeDefinitionParams& params );
+
+                virtual TextDocumentImplementationResult textDocument_implementation(
+                    const TextDocumentImplementationParams& params );
+
+                virtual ReferenceResult textDocument_references( const ReferenceParams& params );
+
+                virtual DocumentHighlightResult textDocument_documentHighlight(
+                    const DocumentHighlightParams& params );
+
+                virtual DocumentSymbolResult textDocument_documentSymbol(
+                    const DocumentSymbolParams& params );
+
+                virtual CodeActionResult textDocument_codeAction( const CodeActionParams& params );
+
+                virtual CodeLensResult textDocument_codeLens( const CodeLensParams& params );
+
+                virtual CodeLensResolveResult codeLens_resolve(
+                    const CodeLensResolveParams& params );
+
+                virtual DocumentLinkResult textDocument_documentLink(
+                    const DocumentLinkParams& params );
+
+                virtual DocumentLinkResolveResult documentLink_resolve(
+                    const DocumentLinkResolveParams& params );
+
+                virtual DocumentColorResult textDocument_documentColor(
+                    const DocumentColorParams& params );
+
+                virtual ColorPresentationResult textDocument_colorPresentation(
+                    const ColorPresentationParams& params );
+
+                virtual DocumentFormattingResult textDocument_formatting(
+                    const DocumentFormattingParams& params );
+
+                virtual DocumentRangeFormattingResult textDocument_rangeFormatting(
+                    const DocumentRangeFormattingParams& params );
+
+                virtual DocumentOnTypeFormattingResult textDocument_onTypeFormatting(
+                    const DocumentOnTypeFormattingParams& params );
+
+                virtual RenameResult textDocument_rename( const RenameParams& params );
+
+                virtual PrepareRenameResult textDocument_prepareRename(
+                    const PrepareRenameParams& params );
+
+                virtual FoldingRangeResult textDocument_foldingRange(
+                    const FoldingRangeParams& params );
+            };
+        }
+    }
+}
+
+#endif  // _LIBSTDHL_CPP_NETWORK_LSP_SERVER_H_
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/cpp/net/tcp/IPv4.cpp
+++ b/src/cpp/net/tcp/IPv4.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/IPv4.h
+++ b/src/cpp/net/tcp/IPv4.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/Packet.h
+++ b/src/cpp/net/tcp/Packet.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/Protocol.h
+++ b/src/cpp/net/tcp/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/Session.h
+++ b/src/cpp/net/tcp/Session.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/Socket.cpp
+++ b/src/cpp/net/tcp/Socket.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/tcp/Socket.h
+++ b/src/cpp/net/tcp/Socket.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/IPv4.cpp
+++ b/src/cpp/net/udp/IPv4.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/IPv4.h
+++ b/src/cpp/net/udp/IPv4.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/Packet.h
+++ b/src/cpp/net/udp/Packet.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/Protocol.h
+++ b/src/cpp/net/udp/Protocol.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/Socket.cpp
+++ b/src/cpp/net/udp/Socket.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/net/udp/Socket.h
+++ b/src/cpp/net/udp/Socket.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/std/ieee802.h
+++ b/src/cpp/std/ieee802.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/std/rfc3986.cpp
+++ b/src/cpp/std/rfc3986.cpp
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/cpp/std/rfc3986.h
+++ b/src/cpp/std/rfc3986.h
@@ -4,6 +4,7 @@
 //
 //  Developed by: Philipp Paulweber
 //                Emmanuel Pescosta
+//                Christian Lascsak
 //                <https://github.com/casm-lang/libstdhl>
 //
 //  This file is part of libstdhl.

--- a/src/py/Licenser.py
+++ b/src/py/Licenser.py
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/src/py/Verbose.py
+++ b/src/py/Verbose.py
@@ -4,6 +4,7 @@
 #
 #   Developed by: Philipp Paulweber
 #                 Emmanuel Pescosta
+#                 Christian Lascsak
 #                 <https://github.com/casm-lang/libstdhl>
 #
 #   This file is part of libstdhl.

--- a/src/xsl/bison/config.xsl
+++ b/src/xsl/bison/config.xsl
@@ -6,6 +6,7 @@
 
     Developed by: Philipp Paulweber
                   Emmanuel Pescosta
+                  Christian Lascsak
                   <https://github.com/casm-lang/libstdhl>
 
     This file is part of libstdhl.

--- a/src/xsl/bison/xml2dw.xsl
+++ b/src/xsl/bison/xml2dw.xsl
@@ -6,6 +6,7 @@
 
     Developed by: Philipp Paulweber
                   Emmanuel Pescosta
+                  Christian Lascsak
                   <https://github.com/casm-lang/libstdhl>
 
     This file is part of libstdhl.

--- a/src/xsl/bison/xml2org.xsl
+++ b/src/xsl/bison/xml2org.xsl
@@ -6,6 +6,7 @@
 
     Developed by: Philipp Paulweber
                   Emmanuel Pescosta
+                  Christian Lascsak
                   <https://github.com/casm-lang/libstdhl>
 
     This file is part of libstdhl.


### PR DESCRIPTION
* Added Server-side response handling
* Added Interface member functions for calling all methods from the <a href= "https://microsoft.github.io/language-server-protocol/specification"> LSP Specification </a> Version 3.13.0.
* Added mapping from json data to interface member functions in ```RequestMessage::process()``` and ```NotificationMessage::process()```  
* Added various necessary Content Classes
* Moved ```Content::validate() ``` functions to new json Namespace
* Added ```validate``` functions for mixed arrays and arrays of two different types. 
* Fixed error in ```ServerInterface::flush()```, where a handled response by the server was not deleted (in commit 61cd437ba763c313cf7e993c0878a78a2be73763)
* Nested ```CompletionItem``` and ```Completion``` in ```TextDocumentClientCapabilities``` as suggested by the specification.
* Seperated unit tests for testing the ```ServerInterface``` and the functionality of ```Content``` in ```etc/test/cpp/net/lsp/interface``` and ```etc/test/cpp/net/lsp/content```
* related to casm-lang/casm#83