### PR TITLE
SourceLocation and File::Path

### DIFF
--- a/etc/test/CMakeLists.txt
+++ b/etc/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library( ${PROJECT}-test OBJECT
   cpp/memory.cpp
   cpp/net/lsp.cpp
   cpp/random.cpp
+  cpp/sourcelocation.cpp
   cpp/std/rfc3986.cpp
   cpp/string.cpp
   cpp/type.cpp

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -59,6 +59,21 @@ TEST( libstdhl_cpp_File, create_and_remove )
     EXPECT_EQ( libstdhl::File::exists( filename ), false );
 }
 
+TEST( libstdhl_cpp_File_PATH, create_and_remove )
+{
+    std::string path = TEST_NAME;
+
+    EXPECT_EQ( libstdhl::File::Path::exists( path ), false );
+
+    libstdhl::File::Path::create( path );
+
+    EXPECT_EQ( libstdhl::File::Path::exists( path ), true );
+
+    libstdhl::File::Path::remove( path );
+
+    EXPECT_EQ( libstdhl::File::Path::exists( path ), false );
+}
+
 //
 //  Local variables:
 //  mode: c++

--- a/etc/test/cpp/sourcelocation.cpp
+++ b/etc/test/cpp/sourcelocation.cpp
@@ -40,45 +40,69 @@
 //  statement from your version.
 //
 
-#pragma once
-#ifndef _LIBSTDHL_H_
-#define _LIBSTDHL_H_
+#include <libstdhl/Test>
 
-/**
-   @brief    TODO
+using namespace libstdhl;
 
-   TODO
-*/
-
-#include <libstdhl/Allocator>
-#include <libstdhl/Ansi>
-#include <libstdhl/Args>
-#include <libstdhl/Binding>
-#include <libstdhl/Enum>
-#include <libstdhl/Environment>
-#include <libstdhl/Exception>
-#include <libstdhl/File>
-#include <libstdhl/Hash>
-#include <libstdhl/Json>
-#include <libstdhl/Labeling>
-#include <libstdhl/List>
-#include <libstdhl/Log>
-#include <libstdhl/Memory>
-#include <libstdhl/Network>
-#include <libstdhl/Random>
-#include <libstdhl/SourceLocation>
-#include <libstdhl/Standard>
-#include <libstdhl/String>
-#include <libstdhl/Type>
-#include <libstdhl/Variadic>
-#include <libstdhl/Version>
-#include <libstdhl/Xml>
-
-namespace libstdhl
+TEST( libstdhl_cpp_SourceLocation, empty )
 {
+    SourceLocation location;
+
+    EXPECT_EQ( location.begin.line, 1 );
+    EXPECT_EQ( location.begin.column, 1 );
+    EXPECT_EQ( location.begin.fileName, nullptr );
+
+    EXPECT_EQ( location.end.line, location.begin.line );
+    EXPECT_EQ( location.end.column, location.begin.column );
+    EXPECT_EQ( location.end.fileName, location.begin.fileName );
+
+    EXPECT_FALSE( location != SourceLocation() );
+
+    location = location + 10;
+    location = location - 10;
+    EXPECT_TRUE( location == SourceLocation() );
+
+    SourceLocation tmp;
+    location += tmp;
+    EXPECT_TRUE( location == SourceLocation() + tmp );
 }
 
-#endif  // _LIBSTDHL_H_
+TEST( libstdhl_cpp_SourceLocation, position )
+{
+    SourceLocation location(
+        SourcePosition( std::make_shared< std::string >( "file.ext" ), 12, 34 ) );
+
+    EXPECT_EQ( location.begin.line, 12 );
+    EXPECT_EQ( location.begin.column, 34 );
+    EXPECT_NE( location.begin.fileName, nullptr );
+    EXPECT_STREQ( location.begin.fileName->c_str(), "file.ext" );
+
+    EXPECT_EQ( location.end.line, location.begin.line );
+    EXPECT_EQ( location.end.column, location.begin.column );
+    EXPECT_EQ( location.end.fileName, location.begin.fileName );
+    EXPECT_STREQ( location.end.fileName->c_str(), location.begin.fileName->c_str() );
+
+    EXPECT_TRUE( location != SourceLocation() );
+}
+
+TEST( libstdhl_cpp_SourceLocation, range )
+{
+    SourceLocation location(
+        SourcePosition( std::make_shared< std::string >( "file.ext" ), 12, 34 ),
+        SourcePosition( std::make_shared< std::string >( "file.ext" ), 56, 78 ) );
+
+    EXPECT_EQ( location.begin.line, 12 );
+    EXPECT_EQ( location.begin.column, 34 );
+    EXPECT_NE( location.begin.fileName, nullptr );
+    EXPECT_STREQ( location.begin.fileName->c_str(), "file.ext" );
+
+    EXPECT_EQ( location.end.line, 56 );
+    EXPECT_EQ( location.end.column, 78 );
+    EXPECT_NE( location.end.fileName, nullptr );
+    EXPECT_STREQ( location.end.fileName->c_str(), "file.ext" );
+
+    EXPECT_TRUE( location != SourceLocation() );
+}
 
 //
 //  Local variables:

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library( ${PROJECT}-cpp OBJECT
   Args.cpp
   Environment.cpp
   Exception.cpp
+  SourceLocation.cpp
   data/file/TextDocument.cpp
   data/log/Category.cpp
   data/log/Chronograph.cpp
@@ -133,6 +134,7 @@ ecm_generate_headers( ${PROJECT}_HEADERS_CPP
     Network
     Optional
     Random
+    SourceLocation
     Standard
     String
     Test

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library( ${PROJECT}-cpp OBJECT
   Args.cpp
   Environment.cpp
   Exception.cpp
+  File.cpp
   SourceLocation.cpp
   data/file/TextDocument.cpp
   data/log/Category.cpp

--- a/src/cpp/File.cpp
+++ b/src/cpp/File.cpp
@@ -1,0 +1,191 @@
+//
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libstdhl>
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libstdhl is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libstdhl
+//  statically or dynamically with other modules is making a combined work
+//  based on libstdhl. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libstdhl give you permission to link libstdhl
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libstdhl. If you modify libstdhl, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#include "File.h"
+
+#if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+using namespace libstdhl;
+using namespace File;
+
+u1 File::exists( const std::fstream& file )
+{
+    return file.is_open();
+}
+
+std::fstream File::open( const std::string& filename, const std::ios_base::openmode mode )
+{
+    std::fstream file;
+
+    file.open( filename, mode );
+
+    if( not exists( file ) )
+    {
+        throw std::invalid_argument( "filename '" + filename + "' does not exist" );
+    }
+
+    return file;
+}
+
+u1 File::exists( const std::string& filename )
+{
+    try
+    {
+        open( filename );
+    }
+    catch( const std::invalid_argument& e )
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void File::remove( const std::string& filename )
+{
+    if( not exists( filename ) )
+    {
+        throw std::invalid_argument(
+            "removing file '" + filename + "' failed, because it does not exist" );
+    }
+
+    auto result = std::remove( filename.c_str() );
+
+    if( result != 0 )
+    {
+        throw std::invalid_argument(
+            "removing file '" + filename + "' failed (error " + std::to_string( result ) + ")" );
+    }
+
+    assert( not exists( filename ) );
+}
+
+u8 File::readLines(
+    const std::string& filename, std::function< void( u32, const std::string& ) > process_line )
+{
+    u32 cnt = 0;
+    std::string line;
+    std::fstream fd( filename );
+
+    if( not exists( fd ) )
+    {
+        return -1;
+    }
+
+    while( std::getline( fd, line ) )
+    {
+        process_line( cnt, line );
+        cnt++;
+    }
+
+    fd.close();
+    return 0;
+}
+
+std::fstream& File::gotoLine( std::fstream& file, const std::size_t num )
+{
+    file.seekg( std::ios::beg );
+
+    for( std::size_t c = 0; c < ( num - 1 ); c++ )
+    {
+        file.ignore( std::numeric_limits< std::streamsize >::max(), '\n' );
+    }
+
+    return file;
+}
+
+std::string File::readLine( const std::string& filename, const u32 num )
+{
+    std::string line;
+
+    auto file = open( filename );
+
+    gotoLine( file, num );
+
+    std::getline( file, line );
+
+    return line;
+}
+
+void File::Path::create( const std::string& path )
+{
+#if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
+    if( _mkdir( path.c_str() ) != 0 )
+#else
+    if( mkdir( path.c_str(), 0755 ) != 0 )
+#endif
+    {
+        throw std::domain_error( "unable to create path '" + path + "'" );
+    }
+}
+
+u1 File::Path::exists( const std::string& path )
+{
+    return File::exists( path );
+}
+
+void File::Path::remove( const std::string& path )
+{
+#if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
+    if( _rmdir( path.c_str() ) != 0 )
+#else
+    if( rmdir( path.c_str() ) != 0 )
+#endif
+    {
+        throw std::domain_error( "unable to remove path '" + path + "'" );
+    }
+}
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/cpp/File.cpp
+++ b/src/cpp/File.cpp
@@ -165,7 +165,11 @@ void File::Path::create( const std::string& path )
 
 u1 File::Path::exists( const std::string& path )
 {
+#if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
+    return _access( path.c_str(), 0 ) == 0;
+#else
     return File::exists( path );
+#endif
 }
 
 void File::Path::remove( const std::string& path )

--- a/src/cpp/File.h
+++ b/src/cpp/File.h
@@ -51,6 +51,9 @@
 #include <functional>
 #include <limits>
 
+#include <sys/stat.h>
+#include <unistd.h>
+
 /**
    @brief    TODO
 
@@ -164,6 +167,30 @@ namespace libstdhl
             std::getline( file, line );
 
             return line;
+        }
+
+        namespace Path
+        {
+            inline void create( const std::string& path )
+            {
+                if( mkdir( path.c_str(), 0755 ) != 0 )
+                {
+                    throw std::domain_error( "unable to create path '" + path + "'" );
+                }
+            }
+
+            inline u1 exists( const std::string& path )
+            {
+                return File::exists( path );
+            }
+
+            inline void remove( const std::string& path )
+            {
+                if( rmdir( path.c_str() ) != 0 )
+                {
+                    throw std::domain_error( "unable to remove path '" + path + "'" );
+                }
+            }
         }
     }
 }

--- a/src/cpp/File.h
+++ b/src/cpp/File.h
@@ -67,130 +67,30 @@ namespace libstdhl
     */
     namespace File
     {
-        inline u1 exists( const std::fstream& file )
-        {
-            return file.is_open();
-        }
+        u1 exists( const std::fstream& file );
 
-        inline std::fstream open(
-            const std::string& filename, const std::ios_base::openmode mode = std::fstream::in )
-        {
-            std::fstream file;
+        std::fstream open(
+            const std::string& filename, const std::ios_base::openmode mode = std::fstream::in );
 
-            file.open( filename, mode );
+        u1 exists( const std::string& filename );
 
-            if( not exists( file ) )
-            {
-                throw std::invalid_argument( "filename '" + filename + "' does not exist" );
-            }
+        void remove( const std::string& filename );
 
-            return file;
-        }
-
-        inline u1 exists( const std::string& filename )
-        {
-            try
-            {
-                open( filename );
-            }
-            catch( const std::invalid_argument& e )
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        inline void remove( const std::string& filename )
-        {
-            if( not exists( filename ) )
-            {
-                throw std::invalid_argument(
-                    "removing file '" + filename + "' failed, because it does not exist" );
-            }
-
-            auto result = std::remove( filename.c_str() );
-
-            if( result != 0 )
-            {
-                throw std::invalid_argument(
-                    "removing file '" + filename + "' failed (error " + std::to_string( result ) +
-                    ")" );
-            }
-
-            assert( not exists( filename ) );
-        }
-
-        inline u8 readLines(
+        u8 readLines(
             const std::string& filename,
-            std::function< void( u32, const std::string& ) > process_line )
-        {
-            u32 cnt = 0;
-            std::string line;
-            std::fstream fd( filename );
+            std::function< void( u32, const std::string& ) > process_line );
 
-            if( not exists( fd ) )
-            {
-                return -1;
-            }
+        std::fstream& gotoLine( std::fstream& file, const std::size_t num );
 
-            while( std::getline( fd, line ) )
-            {
-                process_line( cnt, line );
-                cnt++;
-            }
-
-            fd.close();
-            return 0;
-        }
-
-        inline std::fstream& gotoLine( std::fstream& file, const std::size_t num )
-        {
-            file.seekg( std::ios::beg );
-
-            for( std::size_t c = 0; c < ( num - 1 ); c++ )
-            {
-                file.ignore( std::numeric_limits< std::streamsize >::max(), '\n' );
-            }
-
-            return file;
-        }
-
-        inline std::string readLine( const std::string& filename, const u32 num )
-        {
-            std::string line;
-
-            auto file = open( filename );
-
-            gotoLine( file, num );
-
-            std::getline( file, line );
-
-            return line;
-        }
+        std::string readLine( const std::string& filename, const u32 num );
 
         namespace Path
         {
-            inline void create( const std::string& path )
-            {
-                if( mkdir( path.c_str(), 0755 ) != 0 )
-                {
-                    throw std::domain_error( "unable to create path '" + path + "'" );
-                }
-            }
+            void create( const std::string& path );
 
-            inline u1 exists( const std::string& path )
-            {
-                return File::exists( path );
-            }
+            u1 exists( const std::string& path );
 
-            inline void remove( const std::string& path )
-            {
-                if( rmdir( path.c_str() ) != 0 )
-                {
-                    throw std::domain_error( "unable to remove path '" + path + "'" );
-                }
-            }
+            void remove( const std::string& path );
         }
     }
 }

--- a/src/cpp/SourceLocation.cpp
+++ b/src/cpp/SourceLocation.cpp
@@ -42,6 +42,8 @@
 
 #include "SourceLocation.h"
 
+#include <libstdhl/File>
+
 using namespace libstdhl;
 
 static SourcePosition::value_type add_(
@@ -146,6 +148,45 @@ SourceLocation& SourceLocation::operator+=( SourcePosition::difference_type widt
 SourceLocation& SourceLocation::operator-=( SourcePosition::difference_type width )
 {
     return operator+=( -width );
+}
+
+std::string SourceLocation::read( void ) const
+{
+    std::string range = "";
+    const auto beginL = begin.line;
+    const auto endL = end.line;
+
+    if( not fileName() )
+    {
+        throw std::domain_error( "source location has no file name" );
+    }
+
+    for( auto pos = beginL; pos <= endL; pos++ )
+    {
+        auto line = libstdhl::File::readLine( *fileName(), pos );
+
+        if( pos == beginL and pos == endL )
+        {
+            line = line.substr( begin.column - 1, end.column - begin.column );
+        }
+        else if( pos == beginL )
+        {
+            line = line.substr( begin.column - 1 );
+        }
+        else if( pos == endL )
+        {
+            line = line.substr( 0, end.column - 1 );
+        }
+
+        range += line;
+
+        if( pos != endL )
+        {
+            range += "\n";
+        }
+    }
+
+    return range;
 }
 
 //

--- a/src/cpp/SourceLocation.cpp
+++ b/src/cpp/SourceLocation.cpp
@@ -40,45 +40,113 @@
 //  statement from your version.
 //
 
-#pragma once
-#ifndef _LIBSTDHL_H_
-#define _LIBSTDHL_H_
+#include "SourceLocation.h"
 
-/**
-   @brief    TODO
+using namespace libstdhl;
 
-   TODO
-*/
+static SourcePosition::value_type add_(
+    SourcePosition::value_type lhs,
+    SourcePosition::difference_type rhs,
+    SourcePosition::difference_type min )
+{
+    return ( 0 < rhs || -static_cast< SourcePosition::value_type >( rhs ) < lhs ? rhs + lhs : min );
+}
 
-#include <libstdhl/Allocator>
-#include <libstdhl/Ansi>
-#include <libstdhl/Args>
-#include <libstdhl/Binding>
-#include <libstdhl/Enum>
-#include <libstdhl/Environment>
-#include <libstdhl/Exception>
-#include <libstdhl/File>
-#include <libstdhl/Hash>
-#include <libstdhl/Json>
-#include <libstdhl/Labeling>
-#include <libstdhl/List>
-#include <libstdhl/Log>
-#include <libstdhl/Memory>
-#include <libstdhl/Network>
-#include <libstdhl/Random>
-#include <libstdhl/SourceLocation>
-#include <libstdhl/Standard>
-#include <libstdhl/String>
-#include <libstdhl/Type>
-#include <libstdhl/Variadic>
-#include <libstdhl/Version>
-#include <libstdhl/Xml>
+//
+//
+// SourcePosition
+//
 
-namespace libstdhl
+SourcePosition::SourcePosition( void )
+: SourcePosition( nullptr, 1u, 1u )
 {
 }
 
-#endif  // _LIBSTDHL_H_
+SourcePosition::SourcePosition(
+    const std::shared_ptr< std::string >& fileName, value_type line, value_type column )
+: fileName( fileName )
+, line( line )
+, column( column )
+{
+}
+
+void SourcePosition::lines( difference_type count )
+{
+    if( count != 0 )
+    {
+        column = 1u;
+        line = add_( line, count, 1 );
+    }
+}
+
+void SourcePosition::columns( difference_type count )
+{
+    column = add_( column, count, 1 );
+}
+
+SourcePosition& SourcePosition::operator+=( difference_type width )
+{
+    columns( width );
+    return *this;
+}
+
+SourcePosition& SourcePosition::operator-=( difference_type width )
+{
+    return operator+=( -width );
+}
+
+//
+//
+// SourceLocation
+//
+
+SourceLocation::SourceLocation( const SourcePosition& position )
+: SourceLocation( position, position )
+{
+}
+
+SourceLocation::SourceLocation( const SourcePosition& begin, const SourcePosition& end )
+: begin( begin )
+, end( end )
+{
+}
+
+void SourceLocation::step( void )
+{
+    begin = end;
+}
+
+void SourceLocation::columns( SourcePosition::difference_type count )
+{
+    end += count;
+}
+
+void SourceLocation::lines( SourcePosition::difference_type count )
+{
+    end.lines( count );
+}
+
+const std::shared_ptr< std::string >& SourceLocation::fileName( void ) const
+{
+    return begin.fileName;
+}
+
+SourceLocation& SourceLocation::operator+=( const SourceLocation& rhs )
+{
+    end = rhs.end;
+    return *this;
+}
+
+SourceLocation& SourceLocation::operator+=( SourcePosition::difference_type width )
+{
+    columns( width );
+    return *this;
+}
+
+SourceLocation& SourceLocation::operator-=( SourcePosition::difference_type width )
+{
+    return operator+=( -width );
+}
 
 //
 //  Local variables:

--- a/src/cpp/SourceLocation.h
+++ b/src/cpp/SourceLocation.h
@@ -46,7 +46,6 @@
 #include <libstdhl/Type>
 
 #include <memory>
-#include <sstream>
 
 namespace libstdhl
 {

--- a/src/cpp/SourceLocation.h
+++ b/src/cpp/SourceLocation.h
@@ -162,6 +162,8 @@ namespace libstdhl
             }
         }
 
+        std::string read( void ) const;
+
       public:
         SourcePosition begin;
         SourcePosition end;

--- a/src/cpp/SourceLocation.h
+++ b/src/cpp/SourceLocation.h
@@ -1,0 +1,181 @@
+//
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libstdhl>
+//
+//  This file is part of libstdhl.
+//
+//  libstdhl is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libstdhl is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libstdhl. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libstdhl is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libstdhl
+//  statically or dynamically with other modules is making a combined work
+//  based on libstdhl. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libstdhl give you permission to link libstdhl
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libstdhl. If you modify libstdhl, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#ifndef _LIBSTDHL_SOURCE_LOCATION_H_
+#define _LIBSTDHL_SOURCE_LOCATION_H_
+
+#include <libstdhl/Type>
+
+#include <memory>
+#include <sstream>
+
+namespace libstdhl
+{
+    class SourcePosition
+    {
+      public:
+        using value_type = u32;
+        using difference_type = i32;
+
+      public:
+        explicit SourcePosition( void );
+
+        SourcePosition(
+            const std::shared_ptr< std::string >& fileName, value_type line, value_type column );
+
+        void lines( difference_type count );
+
+        void columns( difference_type count );
+
+        SourcePosition& operator+=( difference_type width );
+
+        friend SourcePosition operator+( SourcePosition lhs, difference_type width )
+        {
+            return lhs += width;
+        }
+
+        SourcePosition& operator-=( difference_type width );
+
+        friend SourcePosition operator-( SourcePosition lhs, difference_type width )
+        {
+            return lhs += -width;
+        }
+
+        friend bool operator==( const SourcePosition& lhs, const SourcePosition& rhs )
+        {
+            return ( lhs.line == rhs.line ) and ( lhs.column == rhs.column ) and
+                   ( ( lhs.fileName == rhs.fileName ) or
+                     ( lhs.fileName and rhs.fileName and *lhs.fileName == *rhs.fileName ) );
+        }
+
+        friend bool operator!=( const SourcePosition& lhs, const SourcePosition& rhs )
+        {
+            return not( lhs == rhs );
+        }
+
+        friend std::ostream& operator<<( std::ostream& stream, const SourcePosition& position )
+        {
+            return stream << std::to_string( position.line ) << ":"
+                          << std::to_string( position.column );
+        }
+
+      public:
+        std::shared_ptr< std::string > fileName;
+        value_type line;
+        value_type column;
+    };
+
+    class SourceLocation
+    {
+      public:
+        explicit SourceLocation( const SourcePosition& position = SourcePosition() );
+
+        SourceLocation( const SourcePosition& begin, const SourcePosition& end );
+
+        void step( void );
+
+        void columns( SourcePosition::difference_type count );
+
+        void lines( SourcePosition::difference_type count );
+
+        const std::shared_ptr< std::string >& fileName( void ) const;
+
+        SourceLocation& operator+=( const SourceLocation& rhs );
+
+        friend SourceLocation operator+( SourceLocation lhs, const SourceLocation& rhs )
+        {
+            return lhs += rhs;
+        }
+
+        SourceLocation& operator+=( SourcePosition::difference_type width );
+
+        friend SourceLocation operator+( SourceLocation lhs, SourcePosition::difference_type width )
+        {
+            return lhs += width;
+        }
+
+        SourceLocation& operator-=( SourcePosition::difference_type width );
+
+        friend SourceLocation operator-( SourceLocation lhs, SourcePosition::difference_type width )
+        {
+            return lhs += -width;
+        }
+
+        friend bool operator==( const SourceLocation& lhs, const SourceLocation& rhs )
+        {
+            return lhs.begin == rhs.begin and lhs.end == rhs.end;
+        }
+
+        friend bool operator!=( const SourceLocation& lhs, const SourceLocation& rhs )
+        {
+            return not( lhs == rhs );
+        }
+
+        friend std::ostream& operator<<( std::ostream& stream, const SourceLocation& location )
+        {
+            if( location.begin != location.end )
+            {
+                return stream << location.begin << ".." << location.end;
+            }
+            else
+            {
+                return stream << location.begin;
+            }
+        }
+
+      public:
+        SourcePosition begin;
+        SourcePosition end;
+    };
+}
+
+#endif  // _LIBSTDHL_SOURCE_LOCATION_H_
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/cpp/Type.h
+++ b/src/cpp/Type.h
@@ -45,6 +45,7 @@
 #define _LIBSTDHL_CPP_TYPE_H_
 
 #include <cstdint>
+#include <sstream>
 #include <string>
 
 /**

--- a/src/cpp/data/file/TextDocument.cpp
+++ b/src/cpp/data/file/TextDocument.cpp
@@ -45,14 +45,14 @@
 using namespace libstdhl;
 using namespace File;
 
-TextDocument::TextDocument( const Path& path, const std::string& extension )
+TextDocument::TextDocument( const TextDocument::Path& path, const std::string& extension )
 : m_path( path )
 , m_extension( extension )
 , m_data()
 {
 }
 
-const Path& TextDocument::path( void ) const
+const TextDocument::Path& TextDocument::path( void ) const
 {
     return m_path;
 }

--- a/src/cpp/data/file/TextDocument.h
+++ b/src/cpp/data/file/TextDocument.h
@@ -63,12 +63,12 @@ namespace libstdhl
     */
     namespace File
     {
-        using Path = Standard::RFC3986::UniformResourceIdentifier;
-
         class TextDocument
         {
           public:
             using Ptr = std::shared_ptr< TextDocument >;
+
+            using Path = Standard::RFC3986::URI;
 
             TextDocument( const Path& path, const std::string& extension );
 


### PR DESCRIPTION
- introduces generic `SourceLocation` class, which forms the basic source information element in (f)lex/bison/yacc lexer/parser-based implementations
- added `File::Path` utility functions
- related to casm-lang/casm#34