### PR TITLE
Extend Optional

### DIFF
--- a/src/cpp/Optional.h
+++ b/src/cpp/Optional.h
@@ -87,6 +87,11 @@ namespace libstdhl
             }
             return *( *this );
         }
+
+        constexpr bool has_value( void ) const noexcept
+        {
+            return !!( *this );
+        }
     };
 }
 

--- a/src/cpp/Optional.h
+++ b/src/cpp/Optional.h
@@ -93,6 +93,8 @@ namespace libstdhl
             return !!( *this );
         }
     };
+
+    constexpr auto nullopt = std::experimental::nullopt;
 }
 
 #endif  // _LIBSTDHL_CPP_OPTIONAL_H_


### PR DESCRIPTION
* Add `has_value` method  as defined in https://en.cppreference.com/w/cpp/utility/optional/operator_bool
* Add `nullopt` constant which denotes an empty optional