### PR TITLE
File and Directory Path Checking Behavior and File Functionalities

### DIFF
--- a/.cmake/Findlibstdhl.cmake
+++ b/.cmake/Findlibstdhl.cmake
@@ -73,6 +73,5 @@ endif()
 set( LIBSTDHL_LIBRARY
   ${LIBSTDHL_LIBRARY}
   Threads::Threads
-  stdc++fs
   PARENT_SCOPE
   )

--- a/.cmake/Findlibstdhl.cmake
+++ b/.cmake/Findlibstdhl.cmake
@@ -69,3 +69,10 @@ if( EXISTS "${LIBSTDHL_LIBRARY}" AND ${LIBSTDHL_LIBRARY} )
 else()
   set( LIBSTDHL_FOUND FALSE PARENT_SCOPE )
 endif()
+
+set( LIBSTDHL_LIBRARY
+  ${LIBSTDHL_LIBRARY}
+  Threads::Threads
+  stdc++fs
+  PARENT_SCOPE
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if( ${LIBGTEST_FOUND} )
     ${LIBGTEST_LIBRARY}
     ${LIBGTEST_MAIN}
     Threads::Threads
+    stdc++fs
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ if( ${LIBGTEST_FOUND} )
     ${LIBGTEST_LIBRARY}
     ${LIBGTEST_MAIN}
     Threads::Threads
-    stdc++fs
     )
 endif()
 

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -64,6 +64,7 @@ TEST( libstdhl_cpp_File, create_exists_remove )
     EXPECT_TRUE( libstdhl::File::exists( file ) );
 
     // CLEANUP
+    file.close();
     libstdhl::File::remove( filename );
     EXPECT_FALSE( libstdhl::File::exists( filename ) );
 }

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -45,7 +45,7 @@
 
 using namespace libstdhl;
 
-TEST( libstdhl_cpp_File, create_and_remove )
+TEST( libstdhl_cpp_File, create_exists_remove )
 {
     std::string filename = TEST_NAME + ".txt";
 
@@ -54,13 +54,14 @@ TEST( libstdhl_cpp_File, create_and_remove )
     libstdhl::File::open( filename, std::ios::out | std::ios::trunc );
 
     EXPECT_EQ( libstdhl::File::exists( filename ), true );
+    EXPECT_EQ( libstdhl::File::Path::exists( filename ), false );
 
     libstdhl::File::remove( filename );
 
     EXPECT_EQ( libstdhl::File::exists( filename ), false );
 }
 
-TEST( libstdhl_cpp_File_PATH, create_and_remove )
+TEST( libstdhl_cpp_File_Path, create_exists_remove )
 {
     std::string path = TEST_NAME;
 
@@ -69,6 +70,7 @@ TEST( libstdhl_cpp_File_PATH, create_and_remove )
     libstdhl::File::Path::create( path );
 
     EXPECT_EQ( libstdhl::File::Path::exists( path ), true );
+    EXPECT_EQ( libstdhl::File::exists( path ), false );
 
     libstdhl::File::Path::remove( path );
 

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -90,6 +90,99 @@ TEST( libstdhl_cpp_File, does_not_exist_during_remove_triggers_exception )
     EXPECT_THROW( libstdhl::File::remove( filename ), std::invalid_argument );
 }
 
+TEST( libstdhl_cpp_File, readLines )
+{
+    // GIVEN
+    static const auto source = R"***(
+foo
+bar foo
+qux bar foo
+eof)***";
+    const std::string filename = TEST_NAME + ".txt";
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+    auto file = libstdhl::File::open( filename, std::fstream::out );
+    file << source;
+    file.close();
+
+    // WHEN
+    EXPECT_TRUE( libstdhl::File::exists( filename ) );
+    const std::vector< std::string > sourceLineStrings = {
+        "", "foo", "bar foo", "qux bar foo", "eof"
+    };
+
+    // THEN
+    auto sourceLineCounter = 0;
+    const auto result = libstdhl::File::readLines(
+        filename, [&]( u32 readLineCounter, const std::string& readLineString ) {
+            EXPECT_EQ( readLineCounter, sourceLineCounter );
+            EXPECT_STREQ( readLineString.c_str(), sourceLineStrings[ readLineCounter ].c_str() );
+            sourceLineCounter++;
+        } );
+    EXPECT_EQ( result, 0 );
+
+    // CLEANUP
+    libstdhl::File::remove( filename );
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+}
+
+TEST( libstdhl_cpp_File, readLine_at_specific_line_number )
+{
+    // GIVEN
+    static const auto source = R"***(
+foo
+bar foo
+qux bar foo
+eof)***";
+    const std::string filename = TEST_NAME + ".txt";
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+    auto file = libstdhl::File::open( filename, std::fstream::out );
+    file << source;
+    file.close();
+
+    // WHEN
+    EXPECT_TRUE( libstdhl::File::exists( filename ) );
+
+    // THEN
+    EXPECT_STREQ( libstdhl::File::readLine( filename, 1 ).c_str(), "" );
+    EXPECT_STREQ( libstdhl::File::readLine( filename, 2 ).c_str(), "foo" );
+    EXPECT_STREQ( libstdhl::File::readLine( filename, 3 ).c_str(), "bar foo" );
+    EXPECT_STREQ( libstdhl::File::readLine( filename, 4 ).c_str(), "qux bar foo" );
+    EXPECT_STREQ( libstdhl::File::readLine( filename, 5 ).c_str(), "eof" );
+
+    // CLEANUP
+    libstdhl::File::remove( filename );
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+}
+
+TEST( libstdhl_cpp_File, readLine_at_invalid_line_number_triggers_exception )
+{
+    // GIVEN
+    static const auto source = R"***(
+foo
+bar foo
+qux bar foo
+eof)***";
+    const std::string filename = TEST_NAME + ".txt";
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+    auto file = libstdhl::File::open( filename, std::fstream::out );
+    file << source;
+    file.close();
+
+    // WHEN
+    EXPECT_TRUE( libstdhl::File::exists( filename ) );
+
+    // THEN
+    EXPECT_THROW( libstdhl::File::readLine( filename, -4321 ), FileNumberOutOfRangeException );
+    EXPECT_THROW( libstdhl::File::readLine( filename, -1 ), FileNumberOutOfRangeException );
+    EXPECT_THROW( libstdhl::File::readLine( filename, 0 ), FileNumberOutOfRangeException );
+    EXPECT_THROW( libstdhl::File::readLine( filename, 6 ), FileNumberOutOfRangeException );
+    EXPECT_THROW( libstdhl::File::readLine( filename, 1234 ), FileNumberOutOfRangeException );
+
+    // CLEANUP
+    libstdhl::File::remove( filename );
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+}
+
 //
 //
 // File::Path

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -47,34 +47,77 @@ using namespace libstdhl;
 
 TEST( libstdhl_cpp_File, create_exists_remove )
 {
+    // GIVEN
+    std::string filename = TEST_NAME + ".txt";
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+
+    // WHEN
+    auto file = libstdhl::File::open( filename, std::ios::out | std::ios::trunc );
+
+    // THEN
+    EXPECT_TRUE( libstdhl::File::exists( filename ) );
+    EXPECT_TRUE( libstdhl::File::exists( file ) );
+
+    // CLEANUP
+    libstdhl::File::remove( filename );
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+}
+
+TEST( libstdhl_cpp_File, does_not_exist_during_open_triggers_exception )
+{
+    // WHEN
     std::string filename = TEST_NAME + ".txt";
 
-    EXPECT_EQ( libstdhl::File::exists( filename ), false );
-
-    libstdhl::File::open( filename, std::ios::out | std::ios::trunc );
-
-    EXPECT_EQ( libstdhl::File::exists( filename ), true );
-    EXPECT_EQ( libstdhl::File::Path::exists( filename ), false );
-
-    libstdhl::File::remove( filename );
-
-    EXPECT_EQ( libstdhl::File::exists( filename ), false );
+    // THEN
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+    EXPECT_THROW( libstdhl::File::open( filename ), std::invalid_argument );
 }
 
 TEST( libstdhl_cpp_File_Path, create_exists_remove )
 {
+    // GIVEN
     std::string path = TEST_NAME;
+    EXPECT_FALSE( libstdhl::File::Path::exists( path ) );
 
-    EXPECT_EQ( libstdhl::File::Path::exists( path ), false );
-
+    // WHEN
     libstdhl::File::Path::create( path );
 
-    EXPECT_EQ( libstdhl::File::Path::exists( path ), true );
-    EXPECT_EQ( libstdhl::File::exists( path ), false );
+    // THEN
+    EXPECT_TRUE( libstdhl::File::Path::exists( path ) );
 
+    // CLEANUP
     libstdhl::File::Path::remove( path );
+    EXPECT_FALSE( libstdhl::File::Path::exists( path ) );
+}
 
-    EXPECT_EQ( libstdhl::File::Path::exists( path ), false );
+TEST( libstdhl_cpp_File_Path, does_not_exist_during_remove_triggers_exception )
+{
+    // GIVEN
+    std::string path = TEST_NAME;
+
+    // WHEN
+    EXPECT_FALSE( libstdhl::File::Path::exists( path ) );
+
+    // THEN
+    EXPECT_THROW( libstdhl::File::Path::remove( path ), std::domain_error );
+}
+
+TEST( libstdhl_cpp_File_Path, redundant_creation_triggers_exception )
+{
+    // GIVEN
+    std::string path = TEST_NAME;
+
+    // WHEN
+    EXPECT_FALSE( libstdhl::File::Path::exists( path ) );
+    libstdhl::File::Path::create( path );
+    EXPECT_TRUE( libstdhl::File::Path::exists( path ) );
+
+    // THEN
+    EXPECT_THROW( libstdhl::File::Path::create( path ), std::domain_error );
+
+    // CLEANUP
+    libstdhl::File::Path::remove( path );
+    EXPECT_FALSE( libstdhl::File::Path::exists( path ) );
 }
 
 //

--- a/etc/test/cpp/file.cpp
+++ b/etc/test/cpp/file.cpp
@@ -45,6 +45,11 @@
 
 using namespace libstdhl;
 
+//
+//
+// File
+//
+
 TEST( libstdhl_cpp_File, create_exists_remove )
 {
     // GIVEN
@@ -73,6 +78,23 @@ TEST( libstdhl_cpp_File, does_not_exist_during_open_triggers_exception )
     EXPECT_THROW( libstdhl::File::open( filename ), std::invalid_argument );
 }
 
+TEST( libstdhl_cpp_File, does_not_exist_during_remove_triggers_exception )
+{
+    // GIVEN
+    std::string filename = TEST_NAME + ".txt";
+
+    // WHEN
+    EXPECT_FALSE( libstdhl::File::exists( filename ) );
+
+    // THEN
+    EXPECT_THROW( libstdhl::File::remove( filename ), std::invalid_argument );
+}
+
+//
+//
+// File::Path
+//
+
 TEST( libstdhl_cpp_File_Path, create_exists_remove )
 {
     // GIVEN
@@ -84,6 +106,7 @@ TEST( libstdhl_cpp_File_Path, create_exists_remove )
 
     // THEN
     EXPECT_TRUE( libstdhl::File::Path::exists( path ) );
+    EXPECT_FALSE( libstdhl::File::exists( path ) );
 
     // CLEANUP
     libstdhl::File::Path::remove( path );

--- a/src/cpp/File.cpp
+++ b/src/cpp/File.cpp
@@ -48,20 +48,15 @@
 #else
 #include <sys/stat.h>
 #include <unistd.h>
+#include <experimental/filesystem>
 #endif
 
 using namespace libstdhl;
 using namespace File;
 
-u1 File::exists( const std::fstream& file )
-{
-    return file.is_open();
-}
-
 std::fstream File::open( const std::string& filename, const std::ios_base::openmode mode )
 {
     std::fstream file;
-
     file.open( filename, mode );
 
     if( not exists( file ) )
@@ -74,6 +69,11 @@ std::fstream File::open( const std::string& filename, const std::ios_base::openm
 
 u1 File::exists( const std::string& filename )
 {
+    if( not std::experimental::filesystem::is_regular_file( filename ) )
+    {
+        return false;
+    }
+
     try
     {
         open( filename );
@@ -84,6 +84,11 @@ u1 File::exists( const std::string& filename )
     }
 
     return true;
+}
+
+u1 File::exists( const std::fstream& file )
+{
+    return file.is_open();
 }
 
 void File::remove( const std::string& filename )
@@ -166,11 +171,7 @@ void File::Path::create( const std::string& path )
 
 u1 File::Path::exists( const std::string& path )
 {
-#if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
-    return _access( path.c_str(), 0 ) == 0;
-#else
-    return File::exists( path );
-#endif
+    return std::experimental::filesystem::is_directory( path );
 }
 
 void File::Path::remove( const std::string& path )

--- a/src/cpp/File.cpp
+++ b/src/cpp/File.cpp
@@ -133,29 +133,44 @@ u8 File::readLines(
     return 0;
 }
 
-std::fstream& File::gotoLine( std::fstream& file, const std::size_t num )
-{
-    file.seekg( std::ios::beg );
-
-    for( std::size_t c = 0; c < ( num - 1 ); c++ )
-    {
-        file.ignore( std::numeric_limits< std::streamsize >::max(), '\n' );
-    }
-
-    return file;
-}
-
 std::string File::readLine( const std::string& filename, const u32 num )
 {
     std::string line;
 
     auto file = open( filename );
 
-    gotoLine( file, num );
+    try
+    {
+        gotoLine( file, num );
+    }
+    catch( const FileNumberOutOfRangeException& e )
+    {
+        throw FileNumberOutOfRangeException(
+            "unable to read a line from file '" + filename + "', because the " + e.what() );
+    }
 
     std::getline( file, line );
 
     return line;
+}
+
+std::fstream& File::gotoLine( std::fstream& file, const std::size_t lineNumber )
+{
+    file.seekg( std::ios::beg );
+
+    std::size_t lineCounter = lineNumber;
+    while( lineCounter != 1 )
+    {
+        file.ignore( std::numeric_limits< std::streamsize >::max(), '\n' );
+        lineCounter--;
+        if( lineCounter < 0 or file.eof() or file.bad() )
+        {
+            throw FileNumberOutOfRangeException(
+                "file does not contain a line at '" + std::to_string( lineNumber ) + "'" );
+        }
+    }
+
+    return file;
 }
 
 void File::Path::create( const std::string& path )

--- a/src/cpp/File.cpp
+++ b/src/cpp/File.cpp
@@ -45,7 +45,6 @@
 
 #if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
 #include <direct.h>
-#include <fileapi.h>
 #else
 #include <sys/stat.h>
 #include <unistd.h>
@@ -188,8 +187,12 @@ void File::Path::create( const std::string& path )
 u1 File::Path::exists( const std::string& path )
 {
 #if defined( __WIN32__ ) or defined( __WIN32 ) or defined( _WIN32 )
-    const auto pathStatus = GetFileAttributesA( path.c_str() );
-    return ( pathStatus & FILE_ATTRIBUTE_DIRECTORY );
+    struct _stat pathStatus;
+    if( _stat( path.c_str(), &pathStatus ) != 0 )
+    {
+        return false;
+    }
+    return ( pathStatus.st_mode & _S_IFDIR );
 #else
     struct stat pathStatus;
     if( ::stat( path.c_str(), &pathStatus ) != 0 )

--- a/src/cpp/File.h
+++ b/src/cpp/File.h
@@ -68,12 +68,12 @@ namespace libstdhl
     */
     namespace File
     {
-        u1 exists( const std::fstream& file );
-
         std::fstream open(
             const std::string& filename, const std::ios_base::openmode mode = std::fstream::in );
 
         u1 exists( const std::string& filename );
+
+        u1 exists( const std::fstream& file );
 
         void remove( const std::string& filename );
 

--- a/src/cpp/File.h
+++ b/src/cpp/File.h
@@ -45,6 +45,7 @@
 #ifndef _LIBSTDHL_CPP_FILE_H_
 #define _LIBSTDHL_CPP_FILE_H_
 
+#include <libstdhl/Exception>
 #include <libstdhl/Type>
 
 #include <cassert>
@@ -66,6 +67,13 @@ namespace libstdhl
     /**
        @extends Stdhl
     */
+
+    class FileNumberOutOfRangeException : public Exception
+    {
+      public:
+        using Exception::Exception;
+    };
+
     namespace File
     {
         std::fstream open(
@@ -81,9 +89,9 @@ namespace libstdhl
             const std::string& filename,
             std::function< void( u32, const std::string& ) > process_line );
 
-        std::fstream& gotoLine( std::fstream& file, const std::size_t num );
-
         std::string readLine( const std::string& filename, const u32 num );
+
+        std::fstream& gotoLine( std::fstream& file, const std::size_t num );
 
         namespace Path
         {


### PR DESCRIPTION
- incorrect implementation triggers the described by in 6548bfef6c59505ae0bba3671286be24e9629504
- updated unit test
- fixed implementation of 'File::exists()'
- fixed implementation of 'File::Path::exists()'
- fixed implementation of 'File::readLines()'
- fixed implementation of 'File::readLine()'
- updated CMake configuration and integration files
